### PR TITLE
Refine Bounds TypedDict with Required/NotRequired

### DIFF
--- a/primitives.py
+++ b/primitives.py
@@ -4,7 +4,9 @@ from typing import (
     Any,
     Dict,
     Literal,
+    NotRequired,
     Protocol,
+    Required,
     Tuple,
     TypedDict,
 )
@@ -15,12 +17,12 @@ class Point(TypedDict):
     y: int
 
 
-class Bounds(TypedDict, total=False):
-    left: int
-    top: int
-    right: int
-    bottom: int
-    monitor: str
+class Bounds(TypedDict):
+    left: Required[int]
+    top: Required[int]
+    right: Required[int]
+    bottom: Required[int]
+    monitor: NotRequired[str]
 
 
 class GrabResult(Protocol):


### PR DESCRIPTION
## Summary
- use typing.Required and NotRequired to specify required and optional fields in Bounds
- import Required and NotRequired from typing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a68b4c8974832180895ea57ed44c59