### PR TITLE
Use typed monitor dictionaries

### DIFF
--- a/primitives.py
+++ b/primitives.py
@@ -17,6 +17,13 @@ class Point(TypedDict):
     y: int
 
 
+class MonitorDict(TypedDict):
+    left: int
+    top: int
+    width: int
+    height: int
+
+
 class Bounds(TypedDict):
     left: Required[int]
     top: Required[int]


### PR DESCRIPTION
## Summary
- add `MonitorDict` TypedDict for monitor geometry
- type monitor usages in screenshot logic and remove old ignores

## Testing
- `pytest`
- `mypy primitives.py screenshot.py logger.py`


------
https://chatgpt.com/codex/tasks/task_e_68a68c80ca748321a530b297c4d0bcd8