### PR TITLE
refactor: tighten bounds typing

### DIFF
--- a/resolve.py
+++ b/resolve.py
@@ -50,14 +50,16 @@ def _compute_ids(app: Dict[str, Any], element: Dict[str, Any]) -> Tuple[str, str
 
 
 @log_call
-def _bounds_dict(b: Mapping[str, int]) -> Bounds:
-    return {
+def _bounds_dict(b: Mapping[str, int | str]) -> Bounds:
+    bounds: Bounds = {
         "left": int(b["left"]),
         "top": int(b["top"]),
         "right": int(b["right"]),
         "bottom": int(b["bottom"]),
-        **({"monitor": b.get("monitor")} if "monitor" in b else {}),
-    }  # type: ignore[index]
+    }
+    if "monitor" in b:
+        bounds["monitor"] = str(b["monitor"])
+    return bounds
 
 
 def describe_under_cursor(x: int | None = None, y: int | None = None) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- accept bounds mapping with string values and cast coordinates to integers
- convert optional monitor field to string and return typed Bounds

## Testing
- `pre-commit run --files resolve.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a68e396ef0832182925bc260244b9a