### PR TITLE
Add Retry-After header for rate limit responses

### DIFF
--- a/api.py
+++ b/api.py
@@ -76,6 +76,7 @@ async def add_request_id_and_rate_limit(request: Request, call_next):
         metrics.record_request(request.url.path, True)
         envelope = error_response("rate_limit", "rate limit exceeded")
         response = JSONResponse(envelope, status_code=429)
+        response.headers["Retry-After"] = "60"
         response.headers["X-Request-Id"] = request_id
         REQUEST_ID.set(None)
         return response

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -219,6 +219,7 @@ def test_rate_limit(monkeypatch):
     assert resp.status_code == 429
     data = resp.json()
     assert data["error"]["code"] == "rate_limit"
+    assert resp.headers["Retry-After"] == "60"
 
 
 def test_inspect_tesseract_error(monkeypatch):


### PR DESCRIPTION
## Summary
- add `Retry-After` header to 429 responses to respect one-minute rate limit window
- test that rate-limited requests include the `Retry-After` header

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a722b923888321b743d591dce7a3f1