### PR TITLE
Refactor OCR tesseract setup to lazy check

### DIFF
--- a/ocr.py
+++ b/ocr.py
@@ -10,19 +10,29 @@ import shutil
 import os
 
 
-if TESSERACT_CMD:
-    cmd = Path(TESSERACT_CMD)
-    if cmd.is_file() and os.access(cmd, os.X_OK):
-        pytesseract.pytesseract.tesseract_cmd = str(cmd)
-    elif shutil.which(str(cmd)):
-        pytesseract.pytesseract.tesseract_cmd = str(cmd)
-    else:
-        raise RuntimeError("tesseract_missing")
+_tesseract_checked = False
+
+
+def _ensure_tesseract() -> None:
+    """Ensure the Tesseract binary is available and configured."""
+    global _tesseract_checked
+    if _tesseract_checked:
+        return
+    if TESSERACT_CMD:
+        cmd = Path(TESSERACT_CMD)
+        if cmd.is_file() and os.access(cmd, os.X_OK):
+            pytesseract.pytesseract.tesseract_cmd = str(cmd)
+        elif shutil.which(str(cmd)):
+            pytesseract.pytesseract.tesseract_cmd = str(cmd)
+        else:
+            raise RuntimeError("tesseract_missing")
+    _tesseract_checked = True
 
 
 @log_call
 def extract_text(image: PILImage) -> Tuple[str, float]:
     """Run OCR on the given image, returning text and confidence."""
+    _ensure_tesseract()
     try:
         data: Dict[str, Any] = pytesseract.image_to_data(
             image,

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -66,8 +66,10 @@ def test_invalid_tesseract_cmd(monkeypatch):
 
     monkeypatch.setenv("TESSERACT_CMD", "nonexistent")
     importlib.reload(settings_module)
+    importlib.reload(ocr)
+    img = Image.new("RGB", (10, 10))
     with pytest.raises(RuntimeError) as exc:
-        importlib.reload(ocr)
+        ocr.extract_text(img)
     assert "tesseract_missing" in str(exc.value)
     monkeypatch.delenv("TESSERACT_CMD", raising=False)
     importlib.reload(settings_module)


### PR DESCRIPTION
## Summary
- add `_ensure_tesseract` helper to configure tesseract once
- call `_ensure_tesseract` from `extract_text` and remove import-time path validation
- adjust OCR tests for new lazy checking behavior

## Testing
- `pre-commit run --files ocr.py tests/test_ocr.py`

------
https://chatgpt.com/codex/tasks/task_e_68a725b848b88321a9f1a4785a1bbf56