### PR TITLE
Add strict mypy hook for API modules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,11 @@ repos:
         entry: mypy --config-file mypy.ini
         language: system
         files: '^(cli_helpers|logger|settings|primitives)\.py$'
+      - id: mypy-strict
+        name: mypy (strict)
+        entry: mypy --config-file mypy.ini --strict
+        language: system
+        files: '^(api|resolve|screenshot)\.py$'
       - id: pytest
         name: pytest
         entry: pytest -q


### PR DESCRIPTION
## Summary
- run mypy in strict mode for api, resolve, and screenshot modules
- keep existing mypy hook for core modules

## Testing
- `pre-commit run --files api.py resolve.py screenshot.py` *(fails: mypy strict errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a72b09a7e883219f4fed529a98c188