### PR TITLE
Add __all__ to primitives module

### DIFF
--- a/primitives.py
+++ b/primitives.py
@@ -52,3 +52,6 @@ class OkEnvelope(TypedDict):
     ok: Literal[True]
     data: Dict[str, Any]
     meta: Dict[str, Any]
+
+
+__all__ = ["Point", "Bounds", "GrabResult", "ErrorInfo", "ErrorEnvelope", "OkEnvelope"]


### PR DESCRIPTION
## Summary
- export common data structures from `primitives` via `__all__`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a72bd7d2ac83218fc269a4cdef8b77