### PR TITLE
feat: enrich UIA metadata and improve text fusion

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,7 +8,7 @@ Opções podem ser fornecidas via variáveis de ambiente, arquivo `.env` ou arqu
 - `OCR_CFG` – string de configuração extra para o Tesseract (padrão: `--oem 3 --psm 6`)
 - `CAPTURE_WIDTH` – largura da região de captura (padrão: `300`)
 - `CAPTURE_HEIGHT` – altura da região de captura (padrão: `120`)
-- `UIA_THRESHOLD` – limiar de confiança para preferir texto de UIA (padrão: `0.7`)
+- `UIA_THRESHOLD` – limiar da heurística de texto da UIA (padrão: `4.0`)
 - `TESSERACT_CMD` – caminho para o executável do Tesseract, caso não esteja no `PATH`
 - `CAPTURE_LOG_SAMPLE_RATE` – proporção de capturas que geram log (padrão: `0.1`)
 - `CAPTURE_LOG_DEST` – destino dos logs de captura (`stderr` ou `file:caminho`)

--- a/hover_watch.py
+++ b/hover_watch.py
@@ -1,8 +1,9 @@
 import argparse
 import time
 from resolve import describe_under_cursor
-from logger import setup, COMPONENT
+from logger import setup, COMPONENT, get_logger
 from cli_helpers import emit_cli_json_line
+from settings import HOVER_WATCH_HZ, HOVER_WATCH_RUN_AS_ADMIN
 
 
 def main() -> None:
@@ -10,7 +11,10 @@ def main() -> None:
         description="Poll describe_under_cursor at a fixed rate"
     )
     parser.add_argument(
-        "--hz", type=float, default=1.0, help="polling frequency in Hertz"
+        "--hz",
+        type=float,
+        default=HOVER_WATCH_HZ,
+        help="polling frequency in Hertz",
     )
     parser.add_argument("--jsonl", action="store_true", help="Enable JSONL logging")
     parser.add_argument(
@@ -19,6 +23,16 @@ def main() -> None:
     args = parser.parse_args()
     setup(enable=args.jsonl, jsonl=args.jsonl, rate_limit_hz=args.rate_limit_hz)
     COMPONENT.set("cli")
+    logger = get_logger()
+    logger.info(
+        "hover_watch starting",
+        extra={"hz": args.hz, "run_as_admin": HOVER_WATCH_RUN_AS_ADMIN},
+    )
+    if HOVER_WATCH_RUN_AS_ADMIN:
+        try:  # pragma: no cover - best effort
+            logger.warning("run_as_admin requested but elevation not implemented")
+        except Exception:
+            logger.warning("run_as_admin requested but failed to elevate")
     delay = 1.0 / args.hz if args.hz > 0 else 0
     try:
         while True:

--- a/metrics.py
+++ b/metrics.py
@@ -16,6 +16,8 @@ _route_total: Counter[str] = Counter()
 _route_errors: Counter[str] = Counter()
 _route_status: Counter[Tuple[str, int]] = Counter()
 _rate_limited_total = 0
+_gauges: Dict[str, int | float] = {}
+_enums: Dict[str, Counter[str]] = {}
 
 
 def record_time(kind: str, elapsed_ms: int) -> None:
@@ -26,6 +28,14 @@ def record_time(kind: str, elapsed_ms: int) -> None:
 
 def record_fallback(name: str) -> None:
     _fallbacks[name] += 1
+
+
+def record_gauge(name: str, value: int | float) -> None:
+    _gauges[name] = value
+
+
+def record_enum(name: str, value: str) -> None:
+    _enums.setdefault(name, Counter())[value] += 1
 
 
 def record_request(route: str, status: int) -> None:
@@ -70,6 +80,8 @@ def summary() -> Dict:
         "status_total": status_total,
         "rate_limited_total": _rate_limited_total,
         "resets_total": _fallbacks.get("resets", 0),
+        "gauges": dict(_gauges),
+        "enums": {k: dict(v) for k, v in _enums.items()},
     }
 
 
@@ -80,5 +92,7 @@ def reset() -> None:
     _route_total.clear()
     _route_errors.clear()
     _route_status.clear()
+    _gauges.clear()
+    _enums.clear()
     global _rate_limited_total
     _rate_limited_total = 0

--- a/primitives.py
+++ b/primitives.py
@@ -32,6 +32,25 @@ class Bounds(TypedDict):
     monitor: NotRequired[str]
 
 
+class UIAWindowInfo(TypedDict, total=False):
+    handle: int
+    active: bool
+    pid: int
+    title: str
+    app_path: str
+    bounds: Bounds
+
+
+class UIAElementInfo(TypedDict, total=False):
+    control_type: str
+    role: str
+    name: str
+    value: str
+    enabled: bool
+    offscreen: bool
+    bounds: Bounds
+
+
 class GrabResult(Protocol):
     size: Tuple[int, int]
     rgb: bytes
@@ -54,4 +73,13 @@ class OkEnvelope(TypedDict):
     meta: Dict[str, Any]
 
 
-__all__ = ["Point", "Bounds", "GrabResult", "ErrorInfo", "ErrorEnvelope", "OkEnvelope"]
+__all__ = [
+    "Point",
+    "Bounds",
+    "UIAWindowInfo",
+    "UIAElementInfo",
+    "GrabResult",
+    "ErrorInfo",
+    "ErrorEnvelope",
+    "OkEnvelope",
+]

--- a/settings.py
+++ b/settings.py
@@ -14,7 +14,7 @@ DEFAULTS: dict[str, Any] = {
     "OCR_CFG": "--oem 3 --psm 6",
     "CAPTURE_WIDTH": 300,
     "CAPTURE_HEIGHT": 120,
-    "UIA_THRESHOLD": 0.7,
+    "UIA_THRESHOLD": 4.0,
     "TESSERACT_CMD": None,
     "CAPTURE_LOG_SAMPLE_RATE": 0.1,
     "CAPTURE_LOG_DEST": "stderr",
@@ -26,6 +26,8 @@ DEFAULTS: dict[str, Any] = {
     "API_CORS_ORIGINS": "",
     "TRUST_PROXY": False,
     "SAFE_MODE": True,
+    "HOVER_WATCH_HZ": 1.0,
+    "HOVER_WATCH_RUN_AS_ADMIN": False,
 }
 
 CONFIG_SOURCES: dict[str, str] = {}
@@ -88,7 +90,7 @@ def load_settings() -> dict[str, Any]:
             cfg[key] = DEFAULTS[key]
             origins[key] = "default"
 
-    for key in ("UIA_THRESHOLD", "CAPTURE_LOG_SAMPLE_RATE"):
+    for key in ("UIA_THRESHOLD", "CAPTURE_LOG_SAMPLE_RATE", "HOVER_WATCH_HZ"):
         try:
             cfg[key] = float(cfg[key])
         except Exception:
@@ -124,6 +126,12 @@ def load_settings() -> dict[str, Any]:
         "on",
     }
     cfg["SAFE_MODE"] = str(cfg["SAFE_MODE"]).lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    cfg["HOVER_WATCH_RUN_AS_ADMIN"] = str(cfg["HOVER_WATCH_RUN_AS_ADMIN"]).lower() in {
         "1",
         "true",
         "yes",
@@ -180,3 +188,5 @@ API_RATE_LIMIT_PER_MIN = CONFIG["API_RATE_LIMIT_PER_MIN"]
 API_CORS_ORIGINS = CONFIG["API_CORS_ORIGINS"]
 TRUST_PROXY = CONFIG["TRUST_PROXY"]
 SAFE_MODE = CONFIG["SAFE_MODE"]
+HOVER_WATCH_HZ = CONFIG["HOVER_WATCH_HZ"]
+HOVER_WATCH_RUN_AS_ADMIN = CONFIG["HOVER_WATCH_RUN_AS_ADMIN"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -25,7 +25,7 @@ api, logger = get_api_logger()
 def fake_describe_under_cursor(x=None, y=None):
     return {
         "cursor": {"x": 1, "y": 2},
-        "app": {},
+        "window": {},
         "element": {
             "bounds": {"left": 0, "top": 0, "right": 1, "bottom": 1},
             "patterns": ["ValuePattern"],

--- a/tests/test_hover_watch.py
+++ b/tests/test_hover_watch.py
@@ -1,0 +1,27 @@
+import sys
+import time
+import hover_watch
+
+
+def test_hover_watch_uses_settings(monkeypatch):
+    monkeypatch.setattr(hover_watch, "HOVER_WATCH_HZ", 2.0)
+    monkeypatch.setattr(hover_watch, "HOVER_WATCH_RUN_AS_ADMIN", False)
+    monkeypatch.setattr(sys, "argv", ["hover_watch.py"])
+    called = {}
+
+    def fake_desc():
+        return {}
+
+    def fake_emit(info):
+        called["emitted"] = True
+
+    def fake_sleep(delay):
+        called["delay"] = delay
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(hover_watch, "describe_under_cursor", fake_desc)
+    monkeypatch.setattr(hover_watch, "emit_cli_json_line", fake_emit)
+    monkeypatch.setattr(time, "sleep", fake_sleep)
+    hover_watch.main()
+    assert called["emitted"]
+    assert called["delay"] == 0.5

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -25,6 +25,8 @@ def test_metrics_endpoint(monkeypatch):
     metrics.record_time("cursor", 20)
     metrics.record_time("cursor", 30)
     metrics.record_fallback("used_ocr")
+    metrics.record_gauge("text_len", 5)
+    metrics.record_enum("text_source", "ocr")
     metrics.record_request("/inspect", 200)
     metrics.record_request("/inspect", 429)
     client = TestClient(api.app)
@@ -37,3 +39,5 @@ def test_metrics_endpoint(monkeypatch):
     assert data["error_rate"]["/inspect"] == 0.5
     assert data["status_total"]["/inspect"]["429"] == 1
     assert data["rate_limited_total"] == 1
+    assert data["gauges"]["text_len"] == 5
+    assert data["enums"]["text_source"]["ocr"] == 1

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -22,13 +22,17 @@ def get_resolve():
 
 def test_describe_prefers_uia_when_visible(monkeypatch):
     resolve = get_resolve()
-    app = {}
+    window = {}
     element = {
         "bounds": {"left": 0, "top": 0, "right": 100, "bottom": 100},
         "is_offscreen": False,
+        "is_enabled": True,
+        "control_type": "Edit",
+        "name": "foo",
+        "value": "uia_text",
     }
     monkeypatch.setattr(
-        resolve, "get_element_info", lambda x, y: (app, element, "uia_text", 0.9)
+        resolve, "get_element_info", lambda x, y: (window, element, "uia_text", 0.9)
     )
     monkeypatch.setattr(
         resolve, "capture_around", lambda pos, bounds=None: ("img", (0, 0, 0, 0))
@@ -48,13 +52,17 @@ def test_describe_prefers_uia_when_visible(monkeypatch):
 
 def test_describe_prefers_ocr_when_offscreen(monkeypatch):
     resolve = get_resolve()
-    app = {}
+    window = {}
     element = {
         "bounds": {"left": 0, "top": 0, "right": 100, "bottom": 100},
         "is_offscreen": True,
+        "is_enabled": True,
+        "control_type": "Edit",
+        "name": "fo",
+        "value": "",
     }
     monkeypatch.setattr(
-        resolve, "get_element_info", lambda x, y: (app, element, "uia_text", 0.9)
+        resolve, "get_element_info", lambda x, y: (window, element, "uia_text", 0.9)
     )
     monkeypatch.setattr(
         resolve, "capture_around", lambda pos, bounds=None: ("img", (0, 0, 0, 0))
@@ -73,7 +81,14 @@ def test_ids_and_cache(monkeypatch):
         {"control_type": "Pane", "name": "Content"},
         {"control_type": "Edit", "name": "Input"},
     ]
-    app = {"pid": 123, "exe": "app.exe", "window_title": "Main"}
+    window = {
+        "pid": 123,
+        "title": "Main",
+        "app_path": "app.exe",
+        "handle": 1,
+        "active": True,
+        "bounds": None,
+    }
     element = {
         "bounds": {"left": 0, "top": 0, "right": 100, "bottom": 100},
         "is_offscreen": False,
@@ -81,7 +96,7 @@ def test_ids_and_cache(monkeypatch):
         "ancestors": ancestors,
     }
     monkeypatch.setattr(
-        resolve, "get_element_info", lambda x, y: (app, element, "uia", 0.9)
+        resolve, "get_element_info", lambda x, y: (window, element, "uia", 0.9)
     )
     monkeypatch.setattr(
         resolve, "capture_around", lambda pos, bounds=None: ("img", (0, 0, 0, 0))
@@ -104,13 +119,13 @@ def test_ids_and_cache(monkeypatch):
 
 def test_error_capture(monkeypatch):
     resolve = get_resolve()
-    app = {}
+    window = {}
     element = {
         "bounds": {"left": 0, "top": 0, "right": 100, "bottom": 100},
         "is_offscreen": False,
     }
     monkeypatch.setattr(
-        resolve, "get_element_info", lambda x, y: (app, element, "uia_text", 0.9)
+        resolve, "get_element_info", lambda x, y: (window, element, "uia_text", 0.9)
     )
     monkeypatch.setattr(
         resolve, "capture_around", lambda pos, bounds=None: ("img", (0, 0, 0, 0))
@@ -132,14 +147,14 @@ def test_describe_uses_get_position_when_coords_missing(monkeypatch):
         called["count"] += 1
         return {"x": 5, "y": 6}
 
-    app = {}
+    window = {}
     element = {
         "bounds": {"left": 0, "top": 0, "right": 10, "bottom": 10},
         "is_offscreen": False,
     }
     monkeypatch.setattr(resolve, "get_position", fake_get_position)
     monkeypatch.setattr(
-        resolve, "get_element_info", lambda x, y: (app, element, "uia", 0.9)
+        resolve, "get_element_info", lambda x, y: (window, element, "uia", 0.9)
     )
     monkeypatch.setattr(
         resolve, "capture_around", lambda pos, bounds=None: ("img", (0, 0, 0, 0))

--- a/tests/test_uia_import.py
+++ b/tests/test_uia_import.py
@@ -3,16 +3,25 @@ import uia
 
 
 def test_get_element_info_defaults_when_pywinauto_missing(monkeypatch):
-    monkeypatch.setattr(uia, "UIAElementInfo", None)
-    app, element, text, conf = get_element_info(10, 20)
-    assert app == {"pid": None, "exe": None, "window_title": None}
+    monkeypatch.setattr(uia, "PUIAElementInfo", None)
+    window, element, text, conf = get_element_info(10, 20)
+    assert window == {
+        "handle": None,
+        "active": None,
+        "pid": None,
+        "title": None,
+        "app_path": None,
+        "bounds": None,
+    }
     assert element == {
         "control_type": None,
-        "bounds": None,
         "automation_id": None,
         "name": None,
+        "value": None,
+        "role": None,
         "is_enabled": None,
         "is_offscreen": None,
+        "bounds": None,
         "patterns": [],
         "affordances": {},
         "ancestors": [],

--- a/tests/test_uia_metadata.py
+++ b/tests/test_uia_metadata.py
@@ -1,0 +1,39 @@
+import resolve
+
+
+def test_uia_metadata_propagates(monkeypatch):
+    window = {
+        "handle": 1,
+        "active": True,
+        "pid": 42,
+        "title": "Win",
+        "app_path": "path",
+        "bounds": {"left": 0, "top": 0, "right": 10, "bottom": 10},
+    }
+    element = {
+        "control_type": "Text",
+        "name": "name",
+        "value": "",
+        "is_enabled": True,
+        "is_offscreen": False,
+        "bounds": {"left": 1, "top": 1, "right": 5, "bottom": 5},
+        "patterns": [],
+        "affordances": {},
+        "ancestors": [],
+    }
+    monkeypatch.setattr(
+        resolve,
+        "get_element_info",
+        lambda x, y: (window, element, "", 0.0),
+    )
+    monkeypatch.setattr(
+        resolve, "capture_around", lambda pos, bounds=None: ("img", (0, 0, 0, 0))
+    )
+    monkeypatch.setattr(resolve, "extract_text", lambda img: ("", 0.0))
+    info = resolve.describe_under_cursor(0, 0)
+    assert "value" in info["element"]
+    assert "handle" in info["window"]
+    assert "active" in info["window"]
+    b = info["element"]["bounds"]
+    assert b["left"] < b["right"]
+    assert b["top"] < b["bottom"]


### PR DESCRIPTION
## Summary
- expose rich window/element metadata from UIA, including value and activation state
- score UIA vs OCR text with heuristics and record detailed metrics
- configure hover_watch via settings with optional elevation flag

## Testing
- `pre-commit run --files docs/usage.md hover_watch.py metrics.py primitives.py resolve.py settings.py tests/test_api.py tests/test_metrics.py tests/test_resolve.py tests/test_uia_import.py uia.py tests/test_hover_watch.py tests/test_uia_metadata.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7485dd7e48321a9b87ce5357d34fd