### PR TITLE
feat: add deterministic testing hooks and circuit breaker

### DIFF
--- a/Milestone_llm.md
+++ b/Milestone_llm.md
@@ -29,7 +29,7 @@ Os milestones LLM-0…LLM-3 representam a evolução de um **agente local** → 
 ## Milestone LLM-0 — **Agente local (explain-first + tools read‑only)**
 **Objetivo:** rodar a LLM **localmente**, decidir quando usar ferramentas e executar até **3** chamadas por turno via `dispatch()` **em processo** (sem HTTP).
 
-- [ ] **Etapa 1: Loop do agente + parser de toolcall**  
+- [x] **Etapa 1: Loop do agente + parser de toolcall**
   Arquivos: `agent_local.py`  
   **DoD:** suporte a `<toolcall>{ "name": "...", "args": {...} }</toolcall>`, no máx. **3** chamadas por turno; truncar payloads grandes antes de devolver ao modelo; parametrizar backend por **`LLM_ENDPOINT`** e **`LLM_MODEL`**.  
   **Prioridade:** P0 • **Size:** S

--- a/agent_local.py
+++ b/agent_local.py
@@ -1,0 +1,397 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import uuid
+import time
+import random
+import logging
+from typing import Any, Dict, List, Tuple, TypedDict, Protocol, Callable
+
+import requests
+from typing import cast
+
+from dispatcher import dispatch
+from registry import get_tool
+import settings
+import logger as _logger
+import metrics
+
+MAX_TOOL_RESULT_CHARS = 1000
+MAX_TOOL_RESULT_TOKENS = 512
+
+
+
+class ToolCall(TypedDict, total=False):
+    name: str
+    args: Dict[str, Any]
+    id: str
+
+
+class Message(TypedDict, total=False):
+    role: str
+    content: str
+    name: str
+    tool_call_id: str
+
+
+Messages = List[Message]
+
+
+class LLMFn(Protocol):
+    def __call__(
+        self,
+        messages: Messages,
+        *,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+    ) -> str:
+        ...
+
+_TOOLCALL_RE = re.compile(r"<toolcall>(.*?)</toolcall>", re.DOTALL)
+
+
+def _truncate(
+    text: str,
+    char_limit: int = MAX_TOOL_RESULT_CHARS,
+    token_limit: int = MAX_TOOL_RESULT_TOKENS,
+) -> str:
+    tokens = text.split()
+    if len(tokens) > token_limit:
+        removed = len(tokens) - token_limit
+        text = " ".join(tokens[:token_limit]) + f"... [truncated {removed} tokens]"
+    if len(text) > char_limit:
+        return text[:char_limit] + "..." + f" [truncated {len(text) - char_limit} chars]"
+    return text
+
+
+def _parse_toolcalls(content: str) -> Tuple[str, List[ToolCall]]:
+    toolcalls: List[ToolCall] = []
+
+    # Support JSON formats like {"tool_calls": [...]}
+    try:
+        data = json.loads(content)
+    except Exception:
+        data = None
+    if isinstance(data, dict):
+        container: Any | None = None
+        if isinstance(data.get("tool_calls"), list):
+            container = data["tool_calls"]
+        elif isinstance(data.get("tools"), list):
+            container = data["tools"]
+        if container is not None:
+            for item in container:
+                if not isinstance(item, dict):
+                    continue
+                if "function" in item:
+                    func = item.get("function", {}) or {}
+                    name = str(func.get("name", ""))
+                    args_raw = func.get("arguments", {})
+                    try:
+                        args = json.loads(args_raw) if isinstance(args_raw, str) else args_raw
+                    except Exception:
+                        args = {}
+                    toolcalls.append({"name": name, "args": args, "id": item.get("id", "")})
+                else:
+                    name = str(item.get("name", ""))
+                    args = item.get("args", {})
+                    toolcalls.append({"name": name, "args": args, "id": item.get("id", "")})
+            return str(data.get("content", "")).strip(), toolcalls
+
+    def repl(match: re.Match[str]) -> str:
+        inner = match.group(1)
+        data: Dict[str, Any] | None = None
+        try:
+            data = json.loads(inner)
+        except Exception:
+            fixed = inner.replace("'", '"')
+            fixed = re.sub(r",\s*([}\]])", r"\1", fixed)
+            try:
+                data = json.loads(fixed)
+            except Exception:
+                return ""
+        if isinstance(data, dict) and "name" in data:
+            toolcalls.append(
+                {
+                    "name": data.get("name", ""),
+                    "args": data.get("args", {}),
+                    "id": data.get("id", ""),
+                }
+            )
+        return ""
+
+    cleaned = _TOOLCALL_RE.sub(repl, content)
+    return cleaned.strip(), toolcalls
+
+
+def _shrink(messages: Messages, max_msgs: int = 20) -> Messages:
+    if len(messages) <= max_msgs:
+        return messages
+    kept: Messages = [m for m in messages if m["role"] == "user"][:1]
+    kept += messages[-(max_msgs - 1) :]
+    kept.insert(0, {"role": "system", "content": "[context shrunk]"})
+    return kept
+
+
+def _default_llm_backend(
+    endpoint: str | None = None, model: str | None = None
+) -> LLMFn:
+    endpoint = (endpoint or os.getenv("LLM_ENDPOINT") or "").strip()
+    model = (model or os.getenv("LLM_MODEL") or "").strip()
+    if not endpoint or not model:
+        raise RuntimeError("LLM_ENDPOINT e LLM_MODEL obrigatórios")
+
+    def _chat(
+        messages: Messages,
+        *,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+    ) -> str:
+        for attempt, timeout in enumerate((60, 90, 120), 1):
+            try:
+                payload: Dict[str, Any] = {"model": model, "messages": messages}
+                if max_tokens is not None:
+                    payload["max_tokens"] = max_tokens
+                if temperature is not None:
+                    payload["temperature"] = temperature
+                resp = requests.post(endpoint, json=payload, timeout=timeout)
+                resp.raise_for_status()
+                data = cast(Dict[str, Any], resp.json())
+                return str(data["choices"][0]["message"]["content"])
+            except Exception as e:  # pragma: no cover - network
+                if attempt == 3:
+                    raise RuntimeError(f"LLM request failed: {e}") from e
+                time.sleep(attempt + random.uniform(0, 0.5))
+        return ""
+
+    return _chat
+
+
+class Agent:
+    def __init__(
+        self,
+        *,
+        llm: LLMFn | None = None,
+        max_tools: int = 3,
+        safe_mode: bool | None = None,
+        endpoint: str | None = None,
+        model: str | None = None,
+        log: logging.Logger | None = None,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        self.llm: LLMFn = llm or _default_llm_backend(endpoint=endpoint, model=model)
+        self.max_tools = max_tools
+        self.safe_mode = settings.SAFE_MODE if safe_mode is None else safe_mode
+        self.log = log or _logger.get_logger()
+        self.clock = clock or time.time
+
+    def chat(self, prompt: str) -> str:
+        messages: Messages = [{"role": "user", "content": prompt}]
+        tool_calls_used = 0
+        conversation_id = str(uuid.uuid4())
+        turn = 0
+        failure_streak = 0
+
+        while tool_calls_used < self.max_tools:
+            turn += 1
+            start_call = self.clock()
+            reply = self.llm(messages, max_tokens=256, temperature=0.2)
+            elapsed = self.clock() - start_call
+            tokens = len(reply.split())
+            tps = tokens / elapsed if elapsed > 0 else float("inf")
+            metrics.record_gauge("tokens_per_sec", tps)
+            self.log.info(
+                json.dumps(
+                    {
+                        "event": "llm_call",
+                        "elapsed_ms": int(elapsed * 1000),
+                        "tokens": tokens,
+                        "tokens_per_sec": tps,
+                        "conversation_id": conversation_id,
+                        "turn": turn,
+                        "safe_mode": self.safe_mode,
+                    }
+                )
+            )
+            text, toolcalls = _parse_toolcalls(reply)
+            messages.append({"role": "assistant", "content": text})
+            if not toolcalls:
+                return text.strip()
+            for tc in toolcalls:
+                if tool_calls_used >= self.max_tools:
+                    self.log.info(
+                        json.dumps(
+                            {
+                                "event": "tool_limit_reached",
+                                "limit": self.max_tools,
+                                "conversation_id": conversation_id,
+                                "turn": turn,
+                                "request_id": None,
+                                "tool_call_id": None,
+                                "safe_mode": self.safe_mode,
+                            }
+                        )
+                    )
+                    break
+                name = tc.get("name", "")
+                tool = get_tool(name)
+                tool_call_id = tc.get("id") or str(uuid.uuid4())
+                request_id = str(uuid.uuid4())
+                if not tool:
+                    failure_streak += 1
+                    self.log.warning(
+                        json.dumps(
+                            {
+                                "event": "unknown_tool",
+                                "name": name,
+                                "conversation_id": conversation_id,
+                                "turn": turn,
+                                "request_id": request_id,
+                                "tool_call_id": tool_call_id,
+                                "safe_mode": self.safe_mode,
+                            }
+                        )
+                    )
+                    messages.append(
+                        {
+                            "role": "tool",
+                            "name": name,
+                            "tool_call_id": tool_call_id,
+                            "content": f"tool {name} unavailable",
+                        }
+                    )
+                    if failure_streak >= 3:
+                        self.log.warning(
+                            json.dumps(
+                                {
+                                    "event": "circuit_breaker",
+                                    "conversation_id": conversation_id,
+                                    "turn": turn,
+                                    "safe_mode": self.safe_mode,
+                                }
+                            )
+                        )
+                        return "tool failures exceeded"
+                    continue
+                args = tc.get("args", {})
+                schema = tool.get("schema") if isinstance(tool, dict) else None
+                if schema:
+                    missing = [k for k in schema.get("required", []) if k not in args]
+                    if missing:
+                        failure_streak += 1
+                        self.log.warning(
+                            json.dumps(
+                                {
+                                    "event": "invalid_tool_args",
+                                    "name": name,
+                                    "missing": missing,
+                                    "conversation_id": conversation_id,
+                                    "turn": turn,
+                                    "request_id": request_id,
+                                    "tool_call_id": tool_call_id,
+                                    "safe_mode": self.safe_mode,
+                                }
+                            )
+                        )
+                        messages.append(
+                            {
+                                "role": "tool",
+                                "name": name,
+                                "tool_call_id": tool_call_id,
+                                "content": "missing args: " + ", ".join(missing),
+                            }
+                        )
+                        if failure_streak >= 3:
+                            self.log.warning(
+                                json.dumps(
+                                    {
+                                        "event": "circuit_breaker",
+                                        "conversation_id": conversation_id,
+                                        "turn": turn,
+                                        "safe_mode": self.safe_mode,
+                                    }
+                                )
+                            )
+                            return "tool failures exceeded"
+                        continue
+                start = self.clock()
+                envelope = dispatch(tc, request_id=request_id, safe_mode=self.safe_mode)
+                raw = json.dumps(envelope, ensure_ascii=False)
+                payload = _truncate(raw)
+                elapsed_ms = int((self.clock() - start) * 1000)
+                self.log.info(
+                    json.dumps(
+                        {
+                            "event": "toolcall",
+                            "name": name,
+                            "elapsed_ms": elapsed_ms,
+                            "size_before": len(raw),
+                            "size_after": len(payload),
+                            "conversation_id": conversation_id,
+                            "turn": turn,
+                            "request_id": request_id,
+                            "tool_call_id": tool_call_id,
+                            "safe_mode": self.safe_mode,
+                        }
+                    )
+                )
+                messages.append(
+                    {
+                        "role": "tool",
+                        "name": name,
+                        "tool_call_id": tool_call_id,
+                        "content": payload,
+                    }
+                )
+                tool_calls_used += 1
+                if envelope.get("kind") != "ok":
+                    failure_streak += 1
+                else:
+                    failure_streak = 0
+                if failure_streak >= 3:
+                    self.log.warning(
+                        json.dumps(
+                            {
+                                "event": "circuit_breaker",
+                                "conversation_id": conversation_id,
+                                "turn": turn,
+                                "safe_mode": self.safe_mode,
+                            }
+                        )
+                    )
+                    return "tool failures exceeded"
+                messages = _shrink(messages)
+
+        turn += 1
+        start_call = self.clock()
+        final = self.llm(_shrink(messages))
+        elapsed = self.clock() - start_call
+        tokens = len(final.split())
+        tps = tokens / elapsed if elapsed > 0 else float("inf")
+        metrics.record_gauge("tokens_per_sec", tps)
+        self.log.info(
+            json.dumps(
+                {
+                    "event": "llm_call",
+                    "elapsed_ms": int(elapsed * 1000),
+                    "tokens": tokens,
+                    "tokens_per_sec": tps,
+                    "conversation_id": conversation_id,
+                    "turn": turn,
+                    "safe_mode": self.safe_mode,
+                    "final": True,
+                }
+            )
+        )
+        text, _ = _parse_toolcalls(final)
+        return text.strip()
+
+
+__all__ = [
+    "Agent",
+    "_parse_toolcalls",
+    "_truncate",
+    "MAX_TOOL_RESULT_CHARS",
+    "MAX_TOOL_RESULT_TOKENS",
+]

--- a/registry.py
+++ b/registry.py
@@ -16,6 +16,7 @@ def register_tool(
     rate_limit_per_min: int,
     enabled_in_safe_mode: bool,
     func: Callable[..., Any],
+    schema: Dict[str, Any] | None = None,
 ) -> None:
     REGISTRY[name] = {
         "name": name,
@@ -27,6 +28,8 @@ def register_tool(
         "enabled_in_safe_mode": enabled_in_safe_mode,
         "func": func,
     }
+    if schema is not None:
+        REGISTRY[name]["schema"] = schema
 
 
 def get_tool(name: str) -> Dict[str, Any] | None:

--- a/tests/test_agent_local.py
+++ b/tests/test_agent_local.py
@@ -1,0 +1,220 @@
+import agent_local
+import json
+
+import logger
+from typing import Any, List, Dict
+
+from agent_local import (
+    Agent,
+    _parse_toolcalls,
+    _truncate,
+    MAX_TOOL_RESULT_CHARS,
+    MAX_TOOL_RESULT_TOKENS,
+)
+
+
+def test_parse_toolcalls_multiple_and_spaces():
+    text = "Hello<toolcall>{\n \"name\": \"foo\", \"args\": {}}\n</toolcall>world<toolcall>{\"name\":\"bar\"}</toolcall>!"
+    cleaned, tcs = _parse_toolcalls(text)
+    assert cleaned == "Helloworld!"
+    assert [tc["name"] for tc in tcs] == ["foo", "bar"]
+
+
+def test_parse_toolcalls_tolerant_json():
+    text = "<toolcall>{'name': 'baz', 'args': {'a': 1,}}</toolcall>"
+    _, tcs = _parse_toolcalls(text)
+    assert tcs[0]["name"] == "baz"
+    assert tcs[0]["args"] == {"a": 1}
+
+
+def test_parse_toolcalls_with_id():
+    text = '<toolcall>{"name":"foo","id":"123","args":{}}</toolcall>'
+    _, tcs = _parse_toolcalls(text)
+    assert tcs[0]["id"] == "123"
+
+
+def test_parse_toolcalls_alt_format():
+    content = json.dumps(
+        {
+            "tool_calls": [
+                {
+                    "id": "x1",
+                    "function": {"name": "foo", "arguments": json.dumps({"a": 1})},
+                }
+            ]
+        }
+    )
+    text, tcs = _parse_toolcalls(content)
+    assert text == ""
+    assert tcs[0]["name"] == "foo"
+    assert tcs[0]["args"] == {"a": 1}
+    assert tcs[0]["id"] == "x1"
+
+
+def test_truncate_payload():
+    payload = "x" * (MAX_TOOL_RESULT_CHARS + 10)
+    out = _truncate(payload)
+    assert out.startswith("x" * MAX_TOOL_RESULT_CHARS)
+    assert out.endswith("[truncated 10 chars]")
+
+
+def test_truncate_payload_tokens():
+    payload = "x " * (MAX_TOOL_RESULT_TOKENS + 5)
+    out = _truncate(payload, char_limit=10000)
+    prefix = " ".join(["x"] * MAX_TOOL_RESULT_TOKENS)
+    assert out.startswith(prefix)
+    assert out.strip().endswith("[truncated 5 tokens]")
+
+
+def test_agent_no_toolcall_returns_text():
+    def llm(messages, **kwargs):
+        return "pong"
+
+    agent = Agent(llm=llm)
+    assert agent.chat("ping") == "pong"
+
+
+def test_agent_unknown_tool_feedback():
+    class LLM:
+        def __init__(self):
+            self.calls = 0
+        def __call__(self, messages, **kwargs):
+            self.calls += 1
+            if self.calls == 1:
+                return '<toolcall>{"name":"missing"}</toolcall>'
+            assert messages[-1]["role"] == "tool"
+            assert "unavailable" in messages[-1]["content"]
+            return "done"
+
+    llm = LLM()
+    agent = Agent(llm=llm)
+    assert agent.chat("hi") == "done"
+
+
+def test_agent_invalid_args(monkeypatch):
+    def llm(messages, **kwargs):
+        if len(messages) == 1:
+            return '<toolcall>{"name":"echo","args":{}}</toolcall>'
+        assert messages[-1]["role"] == "tool"
+        assert "missing args" in messages[-1]["content"]
+        return "done"
+
+    called = False
+
+    def fake_dispatch(req, request_id, safe_mode):
+        nonlocal called
+        called = True
+        return {"kind": "ok"}
+
+    monkeypatch.setattr(agent_local, "dispatch", fake_dispatch)
+    monkeypatch.setattr(
+        agent_local,
+        "get_tool",
+        lambda name: {"name": name, "schema": {"required": ["msg"]}},
+    )
+
+    agent = Agent(llm=llm)
+    assert agent.chat("hi") == "done"
+    assert not called
+
+
+def test_toolcall_log_includes_context(monkeypatch, capsys):
+    def llm(messages, **kwargs):
+        if len(messages) == 1:
+            return '<toolcall>{"name":"echo"}</toolcall>'
+        return "done"
+
+    monkeypatch.setattr(agent_local, "dispatch", lambda req, request_id, safe_mode: {"kind": "ok"})
+    monkeypatch.setattr(agent_local, "get_tool", lambda name: {"name": name})
+    logger.setup(enable=True, jsonl=True)
+    agent = Agent(llm=llm)
+    agent.chat("hi")
+    logs = [json.loads(line) for line in capsys.readouterr().err.strip().splitlines()]
+    tool_log = next(l for l in logs if l.get("event") == "toolcall")
+    assert tool_log["conversation_id"]
+    assert tool_log["turn"] == 1
+    assert tool_log["request_id"]
+    assert tool_log["tool_call_id"]
+    assert "safe_mode" in tool_log
+
+
+def test_agent_respects_tool_limit(monkeypatch):
+    class LLM:
+        def __init__(self):
+            self.calls = 0
+        def __call__(self, messages, **kwargs):
+            self.calls += 1
+            if self.calls == 1:
+                return "".join(
+                    "<toolcall>{\"name\":\"echo\"}</toolcall>" for _ in range(5)
+                )
+            return "done"
+
+    llm = LLM()
+    count = 0
+
+    def fake_dispatch(req, request_id, safe_mode):
+        nonlocal count
+        count += 1
+        return {"kind": "ok", "result": "ok"}
+
+    monkeypatch.setattr(agent_local, "dispatch", fake_dispatch)
+    monkeypatch.setattr(agent_local, "get_tool", lambda name: {"name": name})
+
+    agent = Agent(llm=llm, max_tools=3)
+    assert agent.chat("hi") == "done"
+    assert count == 3
+
+
+def test_llm_tokens_per_second_logged(monkeypatch):
+    class FakeClock:
+        def __init__(self):
+            self.t = 0.0
+        def __call__(self):
+            v = self.t
+            self.t += 1.0
+            return v
+
+    class DummyLogger:
+        def __init__(self):
+            self.logs: List[Dict[str, Any]] = []
+        def info(self, msg: str) -> None:
+            self.logs.append(json.loads(msg))
+        def warning(self, msg: str) -> None:
+            self.logs.append(json.loads(msg))
+
+    clock = FakeClock()
+    log = DummyLogger()
+
+    def llm(messages, **kwargs):
+        return "a b c"
+
+    agent = Agent(llm=llm, log=log, clock=clock)
+    assert agent.chat("hi") == "a b c"
+    entry = next(l for l in log.logs if l.get("event") == "llm_call" and not l.get("final"))
+    assert entry["tokens"] == 3
+    assert entry["tokens_per_sec"] == 3
+
+
+def test_circuit_breaker_on_failures(monkeypatch):
+    class LLM:
+        def __init__(self):
+            self.calls = 0
+        def __call__(self, messages, **kwargs):
+            self.calls += 1
+            return '<toolcall>{"name":"echo"}</toolcall>'
+
+    class DummyLogger:
+        def __init__(self):
+            self.logs: List[Dict[str, Any]] = []
+        def info(self, msg: str) -> None:
+            self.logs.append(json.loads(msg))
+        def warning(self, msg: str) -> None:
+            self.logs.append(json.loads(msg))
+
+    log = DummyLogger()
+    monkeypatch.setattr(agent_local, "get_tool", lambda name: {"name": name})
+    monkeypatch.setattr(agent_local, "dispatch", lambda req, request_id, safe_mode: {"kind": "error"})
+    agent = Agent(llm=LLM(), log=log)
+    assert agent.chat("hi") == "tool failures exceeded"
+    assert any(l.get("event") == "circuit_breaker" for l in log.logs)


### PR DESCRIPTION
## Summary
- inject custom logger and clock into Agent for deterministic testing
- record tokens per second for LLM calls and support alternate tool-call formats
- add simple circuit breaker after three consecutive tool errors

## Testing
- `python -m mypy agent_local.py registry.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8c9eca04c8321819fbbf84b3bc78e