### PR TITLE
Add LLM sandbox experiments and wrapper support

### DIFF
--- a/Milestone_llm.md
+++ b/Milestone_llm.md
@@ -59,12 +59,17 @@ Os milestones LLM-0…LLM-3 representam a evolução de um **agente local** → 
   **Prioridade:** P1 • **Size:** S
 
 - [x] **Etapa 4: Testes E2E mínimos (sem rede real)**
-  Arquivos: `tests/test_agent_local.py`  
-  **DoD:**  
-  - “O que é entropia?” → resposta **sem** tool.  
-  - “dólar hoje?” → exatamente **1** chamada `web.read` (stub) e citação da fonte/data.  
-  - Pedido de tool **não planejada** → bloqueio por policy (`forbidden`).  
+  Arquivos: `tests/test_agent_local.py`
+  **DoD:**
+  - “O que é entropia?” → resposta **sem** tool.
+  - “dólar hoje?” → exatamente **1** chamada `web.read` (stub) e citação da fonte/data.
+  - Pedido de tool **não planejada** → bloqueio por policy (`forbidden`).
   **Prioridade:** P0 • **Size:** S
+
+- [ ] **Etapa final: Contrato da LLM**
+  Arquivos: `agent_local.py`
+  **DoD:** suporte a stop tokens `</toolcall>` e `</s>` via wrapper `chat(messages)->{text,toolcalls,usage}`; o wrapper deve aceitar/passar `stop=["</toolcall>","</s>"]` e o Agent deve aceitar resposta em dict (`{text, toolcalls, usage}`) ou string (fazendo o parse).
+  **Prioridade:** P1 • **Size:** S
 
 **Metas de qualidade (LLM‑0 DoD global):**
 - ≥ **90%** das perguntas conceituais resolvidas **sem** tool.  

--- a/experiments/llm_sandbox/nu_repl.py
+++ b/experiments/llm_sandbox/nu_repl.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List
+
+import requests  # type: ignore[import-untyped]
+
+from agent_local import Agent, _parse_toolcalls
+
+_local_llm = None
+_logged = False
+
+
+def llamacpp_chat(
+    messages: List[Dict[str, Any]],
+    *,
+    max_tokens: int | None = None,
+    temperature: float | None = None,
+) -> Dict[str, Any]:
+    """Minimal wrapper for llama.cpp compatible endpoints."""
+    global _local_llm, _logged
+    stop = ["</toolcall>", "</s>"]
+    endpoint = os.getenv("LLM_ENDPOINT")
+    model = os.getenv("LLM_MODEL", "llama")
+    if endpoint:
+        if not _logged:
+            print(f"[llm] endpoint={endpoint} model={model}")
+            _logged = True
+        payload: Dict[str, Any] = {"model": model, "messages": messages, "stop": stop}
+        if max_tokens is not None:
+            payload["max_tokens"] = max_tokens
+        if temperature is not None:
+            payload["temperature"] = temperature
+        try:
+            resp = requests.post(endpoint, json=payload, timeout=60)
+            resp.raise_for_status()
+        except requests.ConnectionError as e:  # pragma: no cover - network
+            raise RuntimeError(
+                "Falha ao conectar ao endpoint LLM; suba o servidor ou use fallback local"
+            ) from e
+        data = resp.json()
+        content = str(data["choices"][0]["message"]["content"])
+        text, toolcalls = _parse_toolcalls(content)
+        usage = data.get("usage", {})
+        return {"text": text, "toolcalls": toolcalls, "usage": usage}
+    else:
+        if _local_llm is None:
+            print(f"[llm] local model={model}")
+            try:
+                from llama_cpp import Llama
+            except Exception as e:  # pragma: no cover - missing dep
+                raise RuntimeError(
+                    "llama_cpp não disponível; instale ou defina LLM_ENDPOINT"
+                ) from e
+            _local_llm = Llama(model_path=model)
+        result = _local_llm.create_chat_completion(
+            messages=messages,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            stop=stop,
+        )
+        content = str(result["choices"][0]["message"]["content"])
+        text, toolcalls = _parse_toolcalls(content)
+        usage = result.get("usage", {})
+        return {"text": text, "toolcalls": toolcalls, "usage": usage}
+
+MODE = "observer"
+
+
+def main() -> None:
+    agent = Agent(llm=llamacpp_chat, safe_mode=True)  # type: ignore[arg-type]
+    global MODE
+    try:
+        while True:
+            prompt = input(">> ")
+            if not prompt.strip():
+                continue
+            if prompt.startswith("/mode"):
+                parts = prompt.split()
+                if len(parts) == 2 and parts[1] in {"observer", "confirm"}:
+                    MODE = parts[1]
+                    print(f"mode set to {MODE}")
+                else:
+                    print("usage: /mode observer|confirm")
+                continue
+            if prompt.startswith("/stop"):
+                print(["</toolcall>", "</s>"])
+                continue
+            reply = agent.chat(prompt)
+            print(reply)
+    except (EOFError, KeyboardInterrupt):
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/llm_sandbox/run_llm_eval_llamacpp.py
+++ b/experiments/llm_sandbox/run_llm_eval_llamacpp.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import base64
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List
+
+import requests  # type: ignore[import-untyped]
+
+from agent_local import Agent, _parse_toolcalls
+
+SAMPLE_PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y0bZ9wAAAAASUVORK5CYII="
+)  # PNG 1x1
+
+
+def ensure_sample_png(path: str) -> None:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    if not p.exists():
+        p.write_bytes(base64.b64decode(SAMPLE_PNG_B64))
+
+
+_logged = False
+
+
+def llamacpp_chat(
+    messages: List[Dict[str, Any]],
+    *,
+    max_tokens: int | None = None,
+    temperature: float | None = None,
+) -> Dict[str, Any]:
+    """Minimal chat wrapper returning text, tool calls and usage."""
+    global _logged
+    endpoint = os.getenv("LLM_ENDPOINT", "http://localhost:8080/v1/chat/completions")
+    model = os.getenv("LLM_MODEL", "llama")
+    if not _logged:
+        print(f"[llm] endpoint={endpoint} model={model}")
+        _logged = True
+    payload: Dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "stop": ["</toolcall>", "</s>"],
+    }
+    if max_tokens is not None:
+        payload["max_tokens"] = max_tokens
+    if temperature is not None:
+        payload["temperature"] = temperature
+    try:
+        resp = requests.post(endpoint, json=payload, timeout=60)
+        resp.raise_for_status()
+    except requests.ConnectionError as e:  # pragma: no cover - network
+        raise RuntimeError("Falha ao conectar ao endpoint LLM") from e
+    data = resp.json()
+    content = str(data["choices"][0]["message"]["content"])
+    text, toolcalls = _parse_toolcalls(content)
+    usage = data.get("usage", {})
+    return {"text": text, "toolcalls": toolcalls, "usage": usage}
+
+
+def main() -> None:
+    sample = "experiments/llm_sandbox/assets/sample.png"
+    ensure_sample_png(sample)
+    prompts = [
+        "Tire um screenshot da tela.",
+        "Mostre a posição atual do cursor e faça um crop dessa área.",
+        "O que está sob o mouse agora?",
+        f"Rode OCR no arquivo {sample}.",
+        "Liste os arquivos do diretório atual.",
+        "Leia https://example.com e resuma.",
+    ]
+    agent = Agent(llm=llamacpp_chat, safe_mode=True)  # type: ignore[arg-type]
+    results = []
+    for p in prompts:
+        output = agent.chat(p)
+        status = "ok"
+        lowered = output.lower()
+        if any(k in lowered for k in ("forbidden", "policy")):
+            status = "expected_error"
+        results.append({"prompt": p, "output": output, "status": status})
+    out_path = Path("llm_eval_results.json")
+    out_path.write_text(json.dumps(results, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(json.dumps(results, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- clarify LLM contract milestone with explicit stop tokens and dict/string replies
- refine agent to separate raw LLM output and parsed text
- enhance LLM sandbox REPL and evaluator with stop tokens, logging, and local fallback
- generate sample OCR image at runtime during evaluation

## Testing
- `pytest -q`
- `python -m mypy agent_local.py experiments/llm_sandbox/nu_repl.py experiments/llm_sandbox/run_llm_eval_llamacpp.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab7a1234b08321ac3adb8535902189