### PR TITLE
feat: seed sandbox llama.cpp with toolcall preamble

### DIFF
--- a/experiments/llm_sandbox/nu_repl.py
+++ b/experiments/llm_sandbox/nu_repl.py
@@ -1,21 +1,51 @@
 from __future__ import annotations
 
+# setx LLM_MODEL "D:\\modelos\\llama31-8b-instruct\\llama31-8b.Q4_K_M.gguf"
+# setx N_CTX "8192"
+# setx N_GPU_LAYERS "999"
+# setx N_THREADS "8"
+
 # --- ensure repo root on sys.path ---
-import os, sys
+import os
+import sys
+
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 # ------------------------------------
 
-import os
-from typing import Any, Dict, List
+import os  # noqa: E402
+from typing import Any, Dict, List  # noqa: E402
 
-import requests  # type: ignore[import-untyped]
+import requests  # type: ignore[import-untyped]  # noqa: E402
 
-from agent_local import Agent, _parse_toolcalls
+from agent_local import Agent, _parse_toolcalls  # noqa: E402
 
+
+STOP = ["</toolcall>", "</s>"]
 _local_llm = None
 _logged = False
+
+
+def _with_preamble(msgs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return (
+        msgs
+        if any(m.get("role") == "system" for m in msgs)
+        else [
+            {
+                "role": "system",
+                "content": (
+                    "Você é a Nu. Se o pedido exigir ferramenta, responda APENAS com "
+                    '<toolcall>{"name":"...","args":{...}}</toolcall>. '
+                    "Ferramentas disponíveis (read-only, LLM-0): system.capture_screen(); "
+                    "system.ocr(path); system.info(); fs.list(path?); fs.read(path); "
+                    "web.read(url). Depois que eu te enviar o resultado da tool, você "
+                    "poderá responder ao usuário."
+                ),
+            }
+        ]
+        + msgs
+    )
 
 
 def llamacpp_chat(
@@ -26,14 +56,14 @@ def llamacpp_chat(
 ) -> Dict[str, Any]:
     """Minimal wrapper for llama.cpp compatible endpoints."""
     global _local_llm, _logged
-    stop = ["</toolcall>", "</s>"]
+    messages = _with_preamble(messages)
     endpoint = os.getenv("LLM_ENDPOINT")
     model = os.getenv("LLM_MODEL", "llama")
     if endpoint:
         if not _logged:
             print(f"[llm] endpoint={endpoint} model={model}")
             _logged = True
-        payload: Dict[str, Any] = {"model": model, "messages": messages, "stop": stop}
+        payload: Dict[str, Any] = {"model": model, "messages": messages, "stop": STOP}
         if max_tokens is not None:
             payload["max_tokens"] = max_tokens
         if temperature is not None:
@@ -41,35 +71,45 @@ def llamacpp_chat(
         try:
             resp = requests.post(endpoint, json=payload, timeout=60)
             resp.raise_for_status()
-        except requests.ConnectionError as e:  # pragma: no cover - network
+            data = resp.json()
+            content = str(data["choices"][0]["message"]["content"])
+            text, toolcalls = _parse_toolcalls(content)
+            usage = data.get("usage", {})
+            return {"text": text, "toolcalls": toolcalls, "usage": usage}
+        except requests.ConnectionError:
+            print("[llm] endpoint indisponível → usando fallback local llama_cpp")
+
+    if _local_llm is None:
+        try:
+            from llama_cpp import Llama
+        except Exception as e:  # pragma: no cover - missing dep
             raise RuntimeError(
-                "Falha ao conectar ao endpoint LLM; suba o servidor ou use fallback local"
+                "llama_cpp não disponível; instale ou defina LLM_ENDPOINT",
             ) from e
-        data = resp.json()
-        content = str(data["choices"][0]["message"]["content"])
-        text, toolcalls = _parse_toolcalls(content)
-        usage = data.get("usage", {})
-        return {"text": text, "toolcalls": toolcalls, "usage": usage}
-    else:
-        if _local_llm is None:
-            print(f"[llm] local model={model}")
-            try:
-                from llama_cpp import Llama
-            except Exception as e:  # pragma: no cover - missing dep
-                raise RuntimeError(
-                    "llama_cpp não disponível; instale ou defina LLM_ENDPOINT"
-                ) from e
-            _local_llm = Llama(model_path=model)
-        result = _local_llm.create_chat_completion(
-            messages=messages,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            stop=stop,
+        N_CTX = int(os.getenv("N_CTX", "8192"))
+        N_THREADS = int(os.getenv("N_THREADS", "6"))
+        N_GPU_LAYERS = int(os.getenv("N_GPU_LAYERS", "999"))
+        print(
+            f"[llm] local model={model} n_ctx={N_CTX} n_gpu_layers={N_GPU_LAYERS} n_threads={N_THREADS}"
         )
-        content = str(result["choices"][0]["message"]["content"])
-        text, toolcalls = _parse_toolcalls(content)
-        usage = result.get("usage", {})
-        return {"text": text, "toolcalls": toolcalls, "usage": usage}
+        _local_llm = Llama(
+            model_path=model,
+            n_ctx=N_CTX,
+            n_threads=N_THREADS,
+            n_gpu_layers=N_GPU_LAYERS,
+            verbose=False,
+        )
+    result = _local_llm.create_chat_completion(
+        messages=messages,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        stop=["</toolcall>", "</s>"],
+    )
+    content = str(result["choices"][0]["message"]["content"])
+    text, toolcalls = _parse_toolcalls(content)
+    usage = result.get("usage", {})
+    return {"text": text, "toolcalls": toolcalls, "usage": usage}
+
 
 MODE = "observer"
 
@@ -91,7 +131,7 @@ def main() -> None:
                     print("usage: /mode observer|confirm")
                 continue
             if prompt.startswith("/stop"):
-                print(["</toolcall>", "</s>"])
+                print(STOP)
                 continue
             reply = agent.chat(prompt)
             print(reply)

--- a/experiments/llm_sandbox/run_llm_eval_llamacpp.py
+++ b/experiments/llm_sandbox/run_llm_eval_llamacpp.py
@@ -1,25 +1,33 @@
 from __future__ import annotations
 
+# setx LLM_MODEL "D:\\modelos\\llama31-8b-instruct\\llama31-8b.Q4_K_M.gguf"
+# setx N_CTX "8192"
+# setx N_GPU_LAYERS "999"
+# setx N_THREADS "8"
+
 # --- ensure repo root on sys.path ---
-import os, sys
+import os
+import sys
+
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 # ------------------------------------
 
-import base64
-import json
-import os
-from pathlib import Path
-from typing import Any, Dict, List
+import base64  # noqa: E402
+import json  # noqa: E402
+import os  # noqa: E402
+from pathlib import Path  # noqa: E402
+from typing import Any, Dict, List  # noqa: E402
 
-import requests  # type: ignore[import-untyped]
+import requests  # type: ignore[import-untyped]  # noqa: E402
 
-from agent_local import Agent, _parse_toolcalls
+from agent_local import Agent, _parse_toolcalls  # noqa: E402
 
-SAMPLE_PNG_B64 = (
-    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y0bZ9wAAAAASUVORK5CYII="
-)  # PNG 1x1
+
+STOP = ["</toolcall>", "</s>"]
+
+SAMPLE_PNG_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y0bZ9wAAAAASUVORK5CYII="  # PNG 1x1
 
 
 def ensure_sample_png(path: str) -> None:
@@ -35,6 +43,28 @@ _logged = False
 # substitua a função llamacpp_chat por esta versão com fallback local
 _local_llm = None
 
+
+def _with_preamble(msgs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return (
+        msgs
+        if any(m.get("role") == "system" for m in msgs)
+        else [
+            {
+                "role": "system",
+                "content": (
+                    "Você é a Nu. Se o pedido exigir ferramenta, responda APENAS com "
+                    '<toolcall>{"name":"...","args":{...}}</toolcall>. '
+                    "Ferramentas disponíveis (read-only, LLM-0): system.capture_screen(); "
+                    "system.ocr(path); system.info(); fs.list(path?); fs.read(path); "
+                    "web.read(url). Depois que eu te enviar o resultado da tool, você "
+                    "poderá responder ao usuário."
+                ),
+            }
+        ]
+        + msgs
+    )
+
+
 def llamacpp_chat(
     messages: List[Dict[str, Any]],
     *,
@@ -43,7 +73,7 @@ def llamacpp_chat(
 ) -> Dict[str, Any]:
     """Chat wrapper com STOP e fallback p/ llama_cpp local quando não há endpoint."""
     global _local_llm, _logged
-    stop = ["</toolcall>", "</s>"]
+    messages = _with_preamble(messages)
     endpoint = os.getenv("LLM_ENDPOINT", "").strip() or None
     model = os.getenv("LLM_MODEL", "llama")
 
@@ -51,7 +81,7 @@ def llamacpp_chat(
         if not _logged:
             print(f"[llm] endpoint={endpoint} model={model}")
             _logged = True
-        payload: Dict[str, Any] = {"model": model, "messages": messages, "stop": stop}
+        payload: Dict[str, Any] = {"model": model, "messages": messages, "stop": STOP}
         if max_tokens is not None:
             payload["max_tokens"] = max_tokens
         if temperature is not None:
@@ -67,17 +97,27 @@ def llamacpp_chat(
         except requests.ConnectionError:
             print("[llm] endpoint indisponível → usando fallback local llama_cpp")
 
-    # fallback local (llama_cpp)
     if _local_llm is None:
-        print(f"[llm] local model={model}")
         from llama_cpp import Llama  # requer: pip install llama-cpp-python
-        # pode ler N_CTX/N_THREADS/N_GPU_LAYERS se quiser
-        _local_llm = Llama(model_path=model, verbose=False)
+
+        N_CTX = int(os.getenv("N_CTX", "8192"))
+        N_THREADS = int(os.getenv("N_THREADS", "6"))
+        N_GPU_LAYERS = int(os.getenv("N_GPU_LAYERS", "999"))
+        print(
+            f"[llm] local model={model} n_ctx={N_CTX} n_gpu_layers={N_GPU_LAYERS} n_threads={N_THREADS}"
+        )
+        _local_llm = Llama(
+            model_path=model,
+            n_ctx=N_CTX,
+            n_threads=N_THREADS,
+            n_gpu_layers=N_GPU_LAYERS,
+            verbose=False,
+        )
     result = _local_llm.create_chat_completion(
         messages=messages,
         max_tokens=max_tokens,
         temperature=temperature,
-        stop=stop,
+        stop=["</toolcall>", "</s>"],
     )
     content = str(result["choices"][0]["message"]["content"])
     text, toolcalls = _parse_toolcalls(content)
@@ -106,7 +146,9 @@ def main() -> None:
             status = "expected_error"
         results.append({"prompt": p, "output": output, "status": status})
     out_path = Path("llm_eval_results.json")
-    out_path.write_text(json.dumps(results, indent=2, ensure_ascii=False), encoding="utf-8")
+    out_path.write_text(
+        json.dumps(results, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
     print(json.dumps(results, indent=2, ensure_ascii=False))
 
 


### PR DESCRIPTION
## Summary
- prepare sandbox LLM chat for tool calls by injecting a default system preamble
- honor stop tokens for tool calls and use env-based llama_cpp GPU settings for local fallback

## Testing
- `pre-commit run --files experiments/llm_sandbox/run_llm_eval_llamacpp.py experiments/llm_sandbox/nu_repl.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab8a8910c083218badebefb9106fe5