### PR TITLE
Ensure system preamble injection for toolcalls

### DIFF
--- a/experiments/llm_sandbox/nu_repl.py
+++ b/experiments/llm_sandbox/nu_repl.py
@@ -27,25 +27,31 @@ _local_llm = None
 _logged = False
 
 
+PRE = (
+    "Você é a Nu. Se o pedido exigir ferramenta, responda APENAS com "
+    '<toolcall>{"name":"...","args":{...}}</toolcall>. '
+    "Ferramentas (read-only, LLM-0): system.capture_screen(); system.ocr(path); "
+    "system.info(); fs.list(path?); fs.read(path); web.read(url). Depois que eu te "
+    "enviar o resultado da tool, você poderá responder ao usuário."
+)
+
+
 def _with_preamble(msgs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    return (
-        msgs
-        if any(m.get("role") == "system" for m in msgs)
-        else [
-            {
-                "role": "system",
-                "content": (
-                    "Você é a Nu. Se o pedido exigir ferramenta, responda APENAS com "
-                    '<toolcall>{"name":"...","args":{...}}</toolcall>. '
-                    "Ferramentas disponíveis (read-only, LLM-0): system.capture_screen(); "
-                    "system.ocr(path); system.info(); fs.list(path?); fs.read(path); "
-                    "web.read(url). Depois que eu te enviar o resultado da tool, você "
-                    "poderá responder ao usuário."
-                ),
-            }
-        ]
-        + msgs
+    out = list(msgs)
+    idx_last_sys = max(
+        (i for i, m in enumerate(out) if m.get("role") == "system"),
+        default=-1,
     )
+    if idx_last_sys >= 0 and str(out[idx_last_sys].get("content", "")).startswith(
+        "[remaining_tools="
+    ):
+        out[idx_last_sys] = {
+            "role": "system",
+            "content": PRE + " " + out[idx_last_sys]["content"],
+        }
+    else:
+        out = [{"role": "system", "content": PRE}] + out
+    return out
 
 
 def llamacpp_chat(


### PR DESCRIPTION
## Summary
- Always inject Nu toolcall preamble into the last system message or prepend when missing
- Maintain stop tokens and environment-driven llama.cpp fallback

## Testing
- ✅ `pytest`
- ⚠️ `python experiments/llm_sandbox/run_llm_eval_llamacpp.py` (missing `llama_cpp` dependency)


------
https://chatgpt.com/codex/tasks/task_e_68ab8d2fbbb48321817433d8117b6ecc