### PR TITLE
Register sandbox tools at runtime to avoid unknown_tool errors

### DIFF
--- a/Milestone_llm.md
+++ b/Milestone_llm.md
@@ -72,9 +72,25 @@ Os milestones LLM-0…LLM-3 representam a evolução de um **agente local** → 
   **Prioridade:** P1 • **Size:** S
 
 **Metas de qualidade (LLM‑0 DoD global):**
-- ≥ **90%** das perguntas conceituais resolvidas **sem** tool.  
-- ≥ **90%** de consultas “recente” com **1** tool `web.*` e **fonte/data** citadas.  
-- **Nunca** ultrapassar **3** toolcalls por turno.  
+- ≥ **90%** das perguntas conceituais resolvidas **sem** tool.
+- ≥ **90%** de consultas “recente” com **1** tool `web.*` e **fonte/data** citadas.
+- **Nunca** ultrapassar **3** toolcalls por turno.
+
+### Tools read-only disponíveis
+- `system.capture_screen(bounds?)` – screenshot PNG base64 (limite 1 KB)
+- `system.ocr(bounds)` – texto via pytesseract
+- `system.info()` – OS/CPU/RAM/GPU/monitores/safe_mode
+- `fs.list(path)` / `fs.read(path)` – somente dentro do repo ou `experiments/llm_sandbox/assets`
+- `archive.list(path)` / `archive.read(path, inner_path)` – somente `.zip`
+- `web.read(url)` – `timeout=10s`, retorna `text`, `url_final`, `fetched_at`
+- `ui.what_under_mouse()` – `x`, `y`, janela e controle (se disponíveis)
+
+Dependências opcionais (`requirements-optional.txt`): `mss`, `Pillow`, `pytesseract`, `screeninfo`, `pygetwindow`, `psutil`.
+
+### Troubleshooting
+- `missing_dep` – instale dependência ausente (`pip install -r requirements-optional.txt` ou binário externo)
+- `forbidden_path` – caminho fora do allowlist (use diretórios dentro do repositório)
+- `timeout` – reexecute ou verifique conectividade
 
 > Observação: Ferramentas de **ação** (click/type/open/write) **ficam para LLM‑1**. Se desejar já suportar “criar um arquivo” sem tocar no sistema, habilite **opcionalmente** a tool `doc.ppt_generate` que salva **apenas** em `exports/` (SAFE_MODE on).
 

--- a/agent_local.py
+++ b/agent_local.py
@@ -19,6 +19,16 @@ from registry import get_tool, violates_policy
 import settings
 import logger as _logger
 import metrics
+from tools import register_all_tools as _register_all_tools
+
+_TOOLS_READY = False
+
+
+def _ensure_tools() -> None:
+    global _TOOLS_READY
+    if not _TOOLS_READY:
+        _register_all_tools()
+        _TOOLS_READY = True
 
 MAX_TOOL_RESULT_CHARS = 1000
 MAX_TOOL_RESULT_TOKENS = 512
@@ -229,6 +239,7 @@ class Agent:
         self.model = model or os.getenv("LLM_MODEL", "")
 
     def chat(self, prompt: str) -> str:
+        _ensure_tools()
         start_turn = self.clock()
         messages: Messages = [{"role": "user", "content": prompt}]
         tool_calls_used = 0

--- a/api.py
+++ b/api.py
@@ -288,7 +288,7 @@ def tools_call(body: ToolCallModel, request: Request) -> JSONResponse:
     j = (
         res
         if res["kind"] == "ok"
-        else error_response(res.get("code", "tool_error"), res.get("error", ""))
+        else error_response(res.get("code", "tool_error"), res.get("message", ""))
     )
     r = JSONResponse(j, status_code=http)
     r.headers["X-Request-Id"] = req_id

--- a/experiments/llm_sandbox/nu_repl.py
+++ b/experiments/llm_sandbox/nu_repl.py
@@ -21,6 +21,11 @@ from typing import Any, Dict, List  # noqa: E402
 import requests  # type: ignore[import-untyped]  # noqa: E402
 
 from agent_local import Agent, _parse_toolcalls  # noqa: E402
+from tools import register_all_tools  # noqa: E402
+from registry import REGISTRY  # noqa: E402
+
+register_all_tools()
+print(f"[tools] {len(REGISTRY)} registered; optional deps: pip install -r requirements-optional.txt")
 
 
 STOP = ["</toolcall>", "</s>"]
@@ -31,8 +36,9 @@ _logged = False
 PRE = (
     "Você é a Nu. Se o pedido exigir ferramenta, responda APENAS com "
     '<toolcall>{"name":"...","args":{...}}</toolcall>. '
-    "Ferramentas (read-only, LLM-0): system.capture_screen(); system.ocr(path); "
-    "system.info(); fs.list(path?); fs.read(path); web.read(url). "
+    "Ferramentas (read-only, LLM-0): system.capture_screen(); system.ocr(...); "
+    "system.info(); fs.list(...); fs.read(...); archive.list(...); archive.read(...); "
+    "web.read(...); ui.what_under_mouse(). "
     "Quando decidir usar ferramenta, responda APENAS com "
     '<toolcall>{"name":"...","args":{...}}</toolcall> '
     "(nunca texto junto); para URLs use sempre web.read(url); para listar arquivos, "
@@ -46,6 +52,11 @@ _FEW_SHOT = [
     {
         "role": "assistant",
         "content": '<toolcall>{"name":"system.capture_screen","args":{}}</toolcall>',
+    },
+    {"role": "user", "content": "O que está sob o cursor?"},
+    {
+        "role": "assistant",
+        "content": '<toolcall>{"name":"ui.what_under_mouse","args":{}}</toolcall>',
     },
     {"role": "user", "content": "Resumo de https://ex.com"},
     {

--- a/experiments/llm_sandbox/run_llm_eval_llamacpp.py
+++ b/experiments/llm_sandbox/run_llm_eval_llamacpp.py
@@ -24,6 +24,11 @@ from typing import Any, Dict, List  # noqa: E402
 import requests  # type: ignore[import-untyped]  # noqa: E402
 
 from agent_local import Agent, _parse_toolcalls  # noqa: E402
+from tools import register_all_tools  # noqa: E402
+from registry import REGISTRY  # noqa: E402
+
+register_all_tools()
+print(f"[tools] {len(REGISTRY)} registered; optional deps: pip install -r requirements-optional.txt")
 
 
 STOP = ["</toolcall>", "</s>"]
@@ -48,8 +53,9 @@ _local_llm = None
 PRE = (
     "Você é a Nu. Se o pedido exigir ferramenta, responda APENAS com "
     '<toolcall>{"name":"...","args":{...}}</toolcall>. '
-    "Ferramentas (read-only, LLM-0): system.capture_screen(); system.ocr(path); "
-    "system.info(); fs.list(path?); fs.read(path); web.read(url). "
+    "Ferramentas (read-only, LLM-0): system.capture_screen(); system.ocr(...); "
+    "system.info(); fs.list(...); fs.read(...); archive.list(...); archive.read(...); "
+    "web.read(...); ui.what_under_mouse(). "
     "Quando decidir usar ferramenta, responda APENAS com "
     '<toolcall>{"name":"...","args":{...}}</toolcall> '
     "(nunca texto junto); para URLs use sempre web.read(url); para listar arquivos, "
@@ -63,6 +69,11 @@ _FEW_SHOT = [
     {
         "role": "assistant",
         "content": '<toolcall>{"name":"system.capture_screen","args":{}}</toolcall>',
+    },
+    {"role": "user", "content": "O que está sob o cursor?"},
+    {
+        "role": "assistant",
+        "content": '<toolcall>{"name":"ui.what_under_mouse","args":{}}</toolcall>',
     },
     {"role": "user", "content": "Resumo de https://ex.com"},
     {

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,0 +1,6 @@
+mss>=10.1.0
+Pillow>=11.3.0
+pytesseract>=0.3.13
+screeninfo
+pygetwindow
+psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,6 @@
 fastapi
-mss>=10.1.0
-Pillow>=11.3.0
-pytesseract>=0.3.13
 pytest-cov>=5.0.0
-psutil
 httpx
-pygetwindow  # optional
 uvicorn
 requests
 llama-cpp-python>=0.2.90 # fallback local; wheel padrão é CPU-only

--- a/tests/test_tools_readonly.py
+++ b/tests/test_tools_readonly.py
@@ -1,0 +1,122 @@
+import sys
+import types
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from tools import register_all_tools, system, fs, archive, web, ui
+from registry import REGISTRY, clear
+
+
+def test_register_all_tools_idempotent():
+    clear()
+    register_all_tools()
+    n = len(REGISTRY)
+    register_all_tools()
+    assert len(REGISTRY) == n
+
+
+def test_capture_screen_missing_dep(monkeypatch):
+    monkeypatch.setitem(sys.modules, "mss", None)
+    monkeypatch.setitem(sys.modules, "PIL", None)
+    res = system.capture_screen()
+    assert res["kind"] == "error" and res["code"] == "missing_dep"
+
+
+def test_capture_screen_ok(monkeypatch):
+    class Img:
+        def save(self, buf, format="PNG"):
+            buf.write(b"fake")
+
+    monkeypatch.setattr(system, "_grab", lambda b: Img())
+    out = system.capture_screen()
+    assert out["kind"] == "ok"
+
+
+def test_ocr_missing_dep(monkeypatch):
+    class Img:
+        pass
+
+    monkeypatch.setattr(system, "_grab", lambda b: Img())
+    monkeypatch.setitem(
+        sys.modules,
+        "pytesseract",
+        types.SimpleNamespace(image_to_string=lambda img: ""),
+    )
+    monkeypatch.setattr(
+        system.subprocess, "run", lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError())
+    )
+    res = system.ocr({"left": 0, "top": 0, "right": 1, "bottom": 1})
+    assert res["code"] == "missing_dep"
+
+
+def test_ocr_ok(monkeypatch):
+    class Img: ...
+    monkeypatch.setattr(system, "_grab", lambda b: Img())
+
+    pyt = types.SimpleNamespace(image_to_string=lambda img: "hi")
+    monkeypatch.setitem(sys.modules, "pytesseract", pyt)
+    monkeypatch.setattr(system.subprocess, "run", lambda *a, **k: None)
+    res = system.ocr({"left": 0, "top": 0, "right": 1, "bottom": 1})
+    assert res["kind"] == "ok" and "text" in res["result"]
+
+
+def test_fs_allowlist(tmp_path):
+    p = Path.cwd() / "tmp_allow"
+    p.mkdir(exist_ok=True)
+    f = p / "a.txt"
+    f.write_text("hello")
+    assert fs.list(str(p))["kind"] == "ok"
+    assert fs.read(str(f))["kind"] == "ok"
+    bad = tmp_path / "bad.txt"
+    bad.write_text("x")
+    assert fs.read(str(bad))["code"] == "forbidden_path"
+
+
+def test_archive_list_read(tmp_path):
+    p = Path.cwd() / "arc.zip"
+    with zipfile.ZipFile(p, "w") as z:
+        z.writestr("x.txt", "hi")
+    assert archive.list(str(p))["kind"] == "ok"
+    assert archive.read(str(p), "x.txt")["kind"] == "ok"
+    p.unlink()
+
+
+def test_web_read_sanitize(monkeypatch):
+    class Resp:
+        url = "http://a"
+        history = []
+        headers = {"content-type": "text/html"}
+        text = "<h1>hi</h1><script>bad()</script>"
+
+        def raise_for_status(self):
+            return None
+
+    sess = types.SimpleNamespace(get=lambda *a, **k: Resp())
+    monkeypatch.setattr(web.requests, "Session", lambda: sess)
+    out = web.read("http://a")
+    assert "bad" not in out["result"]["text"]
+
+    def timeout(*a, **k):
+        raise web.requests.Timeout()
+
+    monkeypatch.setattr(web.requests, "Session", lambda: types.SimpleNamespace(get=timeout))
+    out = web.read("http://a")
+    assert out["code"] == "timeout"
+
+
+def test_ui_missing_cursor(monkeypatch):
+    monkeypatch.setitem(sys.modules, "cursor", None)
+    res = ui.what_under_mouse()
+    assert res["code"] == "missing_dep"
+
+
+def test_ui_ok(monkeypatch):
+    monkeypatch.setitem(sys.modules, "cursor", types.SimpleNamespace(get_position=lambda: {"x": 1, "y": 2}))
+    fake_win = types.SimpleNamespace(title="t")
+    pgw = types.SimpleNamespace(getWindowsAt=lambda x, y: [fake_win], getActiveWindow=lambda: fake_win)
+    monkeypatch.setitem(sys.modules, "pygetwindow", pgw)
+    monkeypatch.setitem(sys.modules, "uia", types.SimpleNamespace(get_element_info=lambda x, y: ({}, {"role": "r", "name": "n"}, "", 0.0)))
+    res = ui.what_under_mouse()
+    assert res["kind"] == "ok" and res["result"]["window"]

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from registry import register_tool
+from registry import register_tool, REGISTRY
 from . import system, fs, archive, web, ui
 
 __all__ = ["register_all_tools"]
@@ -16,6 +16,8 @@ def register_all_tools() -> None:
         rate_limit_per_min=30,
         enabled_in_safe_mode=True,
         func=system.capture_screen,
+        schema={"args": {"type": "object", "properties": {"bounds": {"type": "object"}}},
+                 "returns": {"type": "object", "properties": {"png_base64": {"type": "string"}}}},
     )
     register_tool(
         name="system.ocr",
@@ -26,16 +28,8 @@ def register_all_tools() -> None:
         rate_limit_per_min=30,
         enabled_in_safe_mode=True,
         func=system.ocr,
-    )
-    register_tool(
-        name="system.uia_query",
-        version="1",
-        summary="uia query",
-        safety="read",
-        timeout_ms=5000,
-        rate_limit_per_min=30,
-        enabled_in_safe_mode=True,
-        func=system.uia_query,
+        schema={"args": {"type": "object", "properties": {"bounds": {"type": "object"},}},
+                 "returns": {"type": "object", "properties": {"text": {"type": "string"}}}},
     )
     register_tool(
         name="system.info",
@@ -46,6 +40,7 @@ def register_all_tools() -> None:
         rate_limit_per_min=60,
         enabled_in_safe_mode=True,
         func=system.info,
+        schema={"args": {"type": "object", "properties": {}}, "returns": {"type": "object"}},
     )
     register_tool(
         name="fs.list",
@@ -56,6 +51,8 @@ def register_all_tools() -> None:
         rate_limit_per_min=60,
         enabled_in_safe_mode=True,
         func=fs.list,
+        schema={"args": {"type": "object", "properties": {"path": {"type": "string"}}},
+                 "returns": {"type": "array", "items": {"type": "string"}}},
     )
     register_tool(
         name="fs.read",
@@ -66,6 +63,8 @@ def register_all_tools() -> None:
         rate_limit_per_min=60,
         enabled_in_safe_mode=True,
         func=fs.read,
+        schema={"args": {"type": "object", "properties": {"path": {"type": "string"}}},
+                 "returns": {"type": "string"}},
     )
     register_tool(
         name="archive.list",
@@ -76,6 +75,8 @@ def register_all_tools() -> None:
         rate_limit_per_min=60,
         enabled_in_safe_mode=True,
         func=archive.list,
+        schema={"args": {"type": "object", "properties": {"path": {"type": "string"}}},
+                 "returns": {"type": "array", "items": {"type": "string"}}},
     )
     register_tool(
         name="archive.read",
@@ -86,6 +87,8 @@ def register_all_tools() -> None:
         rate_limit_per_min=60,
         enabled_in_safe_mode=True,
         func=archive.read,
+        schema={"args": {"type": "object", "properties": {"path": {"type": "string"}, "inner_path": {"type": "string"}}},
+                 "returns": {"type": "object", "properties": {"bytes_b64": {"type": "string"}}}},
     )
     register_tool(
         name="web.read",
@@ -96,6 +99,8 @@ def register_all_tools() -> None:
         rate_limit_per_min=30,
         enabled_in_safe_mode=True,
         func=web.read,
+        schema={"args": {"type": "object", "properties": {"url": {"type": "string"}}},
+                 "returns": {"type": "object", "properties": {"text": {"type": "string"}, "url_final": {"type": "string"}}}},
     )
     register_tool(
         name="ui.what_under_mouse",
@@ -115,19 +120,19 @@ def register_all_tools() -> None:
                     "y": {"type": "integer"},
                     "window": {
                         "type": ["object", "null"],
-                        "properties": {
-                            "title": {"type": "string"},
-                            "app": {"type": "string"},
-                        },
+                        "properties": {"title": {"type": "string"}, "app": {"type": "string"}},
                     },
                     "control": {
                         "type": ["object", "null"],
-                        "properties": {
-                            "role": {"type": "string"},
-                            "name": {"type": "string"},
-                        },
+                        "properties": {"role": {"type": "string"}, "name": {"type": "string"}},
                     },
                 },
             },
         },
     )
+    try:
+        import metrics
+
+        metrics.record_gauge("agent_tool_name_total", len(REGISTRY))
+    except Exception:
+        pass

--- a/tools/archive.py
+++ b/tools/archive.py
@@ -3,47 +3,86 @@ from __future__ import annotations
 import base64
 import zipfile
 from pathlib import Path, PurePosixPath
-from typing import List
+from typing import Dict
+
+from . import fs
 
 MAX_BYTES = 512_000
 MAX_FILES = 200
 
 
-def _check_allow(path: Path, allow: List[str] | None) -> None:
-    allow = allow or []
-    if not any(Path(a) in path.parents or Path(a) == path for a in allow):
-        raise PermissionError("path not allowed")
-
-
-def list(path: str, allow: List[str] | None = None) -> List[str]:
+def list(path: str, allow: list[str] | None = None) -> Dict:
     p = Path(path)
-    _check_allow(p, allow)
-    with zipfile.ZipFile(p) as z:
-        if len(z.infolist()) > MAX_FILES:
-            raise ValueError("too_many_entries")
-        return z.namelist()
+    rp = p.resolve()
+    allowed = fs.ALLOWED + [Path(a) for a in (allow or [])]  # type: ignore[attr-defined]
+    if not any(base in rp.parents or base == rp for base in allowed):
+        return {
+            "kind": "error",
+            "code": "forbidden_path",
+            "message": "path not allowed",
+            "hint": "",
+        }
+    try:
+        with zipfile.ZipFile(p) as z:
+            if len(z.infolist()) > MAX_FILES:
+                return {
+                    "kind": "error",
+                    "code": "bad_args",
+                    "message": "too_many_entries",
+                    "hint": "",
+                }
+            return {"kind": "ok", "result": z.namelist()}
+    except Exception as e:
+        return {"kind": "error", "code": "not_found", "message": str(e), "hint": ""}
 
 
-def read(
-    path: str,
-    inner_path: str,
-    allow: List[str] | None = None,
-    max_bytes: int = MAX_BYTES,
-) -> dict:
+def read(path: str, inner_path: str, allow: list[str] | None = None) -> Dict:
     p = Path(path)
-    _check_allow(p, allow)
-    with zipfile.ZipFile(p) as z:
-        if len(z.infolist()) > MAX_FILES:
-            raise ValueError("too_many_entries")
-        pp = PurePosixPath(inner_path)
-        if pp.is_absolute() or ".." in pp.parts:
-            raise ValueError("bad_path")
-        info = z.getinfo(inner_path)
-        ratio = (info.file_size or 1) / max(info.compress_size or 1, 1)
-        if ratio > 1000 or info.file_size > max_bytes:
-            raise ValueError("too_big")
-        data = z.read(info)[:max_bytes]
-    return {
-        "inner_path": inner_path,
-        "bytes_b64": base64.b64encode(data).decode("ascii"),
-    }
+    rp = p.resolve()
+    allowed = fs.ALLOWED + [Path(a) for a in (allow or [])]  # type: ignore[attr-defined]
+    if not any(base in rp.parents or base == rp for base in allowed):
+        return {
+            "kind": "error",
+            "code": "forbidden_path",
+            "message": "path not allowed",
+            "hint": "",
+        }
+    try:
+        with zipfile.ZipFile(p) as z:
+            if len(z.infolist()) > MAX_FILES:
+                return {
+                    "kind": "error",
+                    "code": "too_many_entries",
+                    "message": "archive too large",
+                    "hint": "",
+                }
+            pp = PurePosixPath(inner_path)
+            if pp.is_absolute() or ".." in pp.parts:
+                return {
+                    "kind": "error",
+                    "code": "bad_args",
+                    "message": "bad_path",
+                    "hint": "",
+                }
+            info = z.getinfo(inner_path)
+            ratio = (info.file_size or 1) / max(info.compress_size or 1, 1)
+            if ratio > 1000 or info.file_size > MAX_BYTES:
+                return {
+                    "kind": "error",
+                    "code": "bad_args",
+                    "message": "too_big",
+                    "hint": "",
+                }
+            data = z.read(info)[:MAX_BYTES]
+            return {
+                "kind": "ok",
+                "result": {
+                    "inner_path": inner_path,
+                    "bytes_b64": base64.b64encode(data).decode("ascii"),
+                },
+            }
+    except Exception as e:
+        return {"kind": "error", "code": "not_found", "message": str(e), "hint": ""}
+
+
+__all__ = ["list", "read"]

--- a/tools/fs.py
+++ b/tools/fs.py
@@ -1,23 +1,61 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List
+from typing import Dict, List
+
+ALLOWED = [Path.cwd(), Path.cwd() / "experiments/llm_sandbox/assets"]
 
 
-def _check_allow(path: Path, allow: List[str] | None) -> None:
-    allow = allow or []
-    if not any(Path(a) in path.parents or Path(a) == path for a in allow):
-        raise PermissionError("path not allowed")
+def _sanitize(text: str) -> str:
+    from agent_local import _redact, _truncate
+
+    return _truncate(_redact(text))
 
 
-def list(path: str, allow: List[str] | None = None) -> List[str]:
+def list(path: str, allow: List[str] | None = None) -> Dict:
     p = Path(path)
-    _check_allow(p, allow)
-    return [child.name for child in p.iterdir()]
+    allowed = ALLOWED + [Path(a) for a in (allow or [])]
+    rp = p.resolve()
+    if not any(base in rp.parents or base == rp for base in allowed):
+        return {
+            "kind": "error",
+            "code": "forbidden_path",
+            "message": "path not allowed",
+            "hint": "",
+        }
+    try:
+        names = [c.name for c in p.iterdir()]
+        return {"kind": "ok", "result": names}
+    except Exception as e:
+        return {
+            "kind": "error",
+            "code": "not_found",
+            "message": str(e),
+            "hint": "",
+        }
 
 
-def read(path: str, allow: List[str] | None = None, max_bytes: int = 100_000) -> str:
+def read(path: str, allow: List[str] | None = None, max_bytes: int = 100_000) -> Dict:
     p = Path(path)
-    _check_allow(p, allow)
-    data = p.read_bytes()[:max_bytes]
-    return data.decode("utf-8", errors="replace")
+    allowed = ALLOWED + [Path(a) for a in (allow or [])]
+    rp = p.resolve()
+    if not any(base in rp.parents or base == rp for base in allowed):
+        return {
+            "kind": "error",
+            "code": "forbidden_path",
+            "message": "path not allowed",
+            "hint": "",
+        }
+    try:
+        data = p.read_bytes()[:max_bytes]
+        return {"kind": "ok", "result": _sanitize(data.decode("utf-8", "replace"))}
+    except Exception as e:
+        return {
+            "kind": "error",
+            "code": "not_found",
+            "message": str(e),
+            "hint": "",
+        }
+
+
+__all__ = ["list", "read"]

--- a/tools/system.py
+++ b/tools/system.py
@@ -3,113 +3,148 @@ from __future__ import annotations
 import base64
 import io
 import platform
-from typing import Any, Dict, Tuple, cast
-
-import psutil
-from settings import SAFE_MODE
-from ocr import extract_text
-from screenshot import capture
-from resolve import describe_under_cursor
+import subprocess
+from typing import Any, Dict, Tuple
 
 
-def _resolve_bounds(
-    bounds: Dict[str, int] | None,
-    window_id: str | None,
-    control_id: str | None,
-) -> Tuple[int, int, int, int] | None:
-    if bounds:
-        return (
-            int(bounds["left"]),
-            int(bounds["top"]),
-            int(bounds["right"]),
-            int(bounds["bottom"]),
-        )
-    if window_id or control_id:
-        try:
-            from api import BOUNDS_CACHE
-        except Exception:  # pragma: no cover - missing API context
-            return None
+# helpers ---------------------------------------------------------------
+
+def _sanitize(text: str) -> str:
+    from agent_local import _redact, _truncate  # lazy import to avoid cycles
+
+    return _truncate(_redact(text))
+
+
+def _grab(bounds: Tuple[int, int, int, int] | None) -> Any:
+    """Return a PIL Image of the screen or raise RuntimeError('missing_dep')."""
+    left = top = 0
+    width = height = 0
+    if bounds is not None:
+        left, top, right, bottom = bounds
+        width, height = right - left, bottom - top
+    try:  # mss path
+        import mss
+        from PIL import Image
+
+        with mss.mss() as sct:  # type: ignore[attr-defined]
+            mon = {
+                "left": left,
+                "top": top,
+                "width": width or sct.monitors[1]["width"],
+                "height": height or sct.monitors[1]["height"],
+            }
+            shot = sct.grab(mon)
+            return Image.frombytes("RGB", shot.size, shot.rgb)
+    except Exception:
+        try:  # fallback to ImageGrab
+            from PIL import ImageGrab
+
+            box = (left, top, left + (width or 0), top + (height or 0)) or None
+            return ImageGrab.grab(box)
+        except Exception as e:
+            raise RuntimeError("missing_dep") from e
+
+
+def capture(bounds: Tuple[int, int, int, int] | None = None) -> Any:
+    return _grab(bounds)
+
+
+# tools ----------------------------------------------------------------
+
+def capture_screen(bounds: Dict[str, int] | None = None) -> Dict[str, Any]:
+    try:
         b = None
-        if control_id:
-            b = BOUNDS_CACHE.get(control_id)
-        if b is None and window_id:
-            b = BOUNDS_CACHE.get(window_id)
-        if b is None:
-            raise ValueError("id_not_found")
-        return (b["left"], b["top"], b["right"], b["bottom"])
-    return None
-
-
-def capture_screen(
-    bounds: Dict[str, int] | None = None,
-    window_id: str | None = None,
-    control_id: str | None = None,
-) -> Dict[str, Any]:
-    """Capture the screen and return PNG bytes as base64."""
-
-    region = _resolve_bounds(bounds, window_id, control_id)
-    img = capture(region)
+        if bounds:
+            b = (bounds["left"], bounds["top"], bounds["right"], bounds["bottom"])
+        img = capture(b)
+    except RuntimeError:
+        return {
+            "kind": "error",
+            "code": "missing_dep",
+            "message": "mss or pillow not available",
+            "hint": "pip install -r requirements-optional.txt",
+        }
     buf = io.BytesIO()
     img.save(buf, format="PNG")
     data = base64.b64encode(buf.getvalue()).decode("ascii")
-    return {"png_base64": data}
+    return {"kind": "ok", "result": {"png_base64": _sanitize(data)}}
 
 
-def ocr(
-    bounds: Dict[str, int] | None = None,
-    window_id: str | None = None,
-    control_id: str | None = None,
-) -> Dict[str, Any]:
-    """Run OCR on the given region from the screen."""
-
-    region = _resolve_bounds(bounds, window_id, control_id)
-    if region is None:
-        raise ValueError("missing_bounds")
-    img = capture(region)
-    text, conf = extract_text(img)
-    return {"text": text, "confidence": conf}
-
-
-def uia_query(x: int, y: int) -> Dict[str, Any]:
-    """Query UIA/resolve for coordinates."""
-
-    return cast(Dict[str, Any], describe_under_cursor(x, y))
+def ocr(bounds: Dict[str, int]) -> Dict[str, Any]:
+    try:
+        subprocess.run(["tesseract", "-v"], check=True, capture_output=True)
+    except Exception:
+        return {
+            "kind": "error",
+            "code": "missing_dep",
+            "message": "tesseract not installed",
+            "hint": "install tesseract and pytesseract",
+        }
+    try:
+        import pytesseract
+    except Exception:
+        return {
+            "kind": "error",
+            "code": "missing_dep",
+            "message": "pytesseract not installed",
+            "hint": "pip install -r requirements-optional.txt",
+        }
+    try:
+        img = capture(
+            (bounds["left"], bounds["top"], bounds["right"], bounds["bottom"])
+        )
+    except RuntimeError:
+        return {
+            "kind": "error",
+            "code": "missing_dep",
+            "message": "mss or pillow not available",
+            "hint": "pip install -r requirements-optional.txt",
+        }
+    text = pytesseract.image_to_string(img)
+    return {"kind": "ok", "result": {"text": _sanitize(text)}}
 
 
 def info() -> Dict[str, Any]:
-    """Return basic system information without network identifiers."""
-
     data: Dict[str, Any] = {
         "os": {
             "name": platform.system(),
             "version": platform.release(),
         },
-        "cpu": {"count": psutil.cpu_count(logical=True)},
-        "ram_bytes": psutil.virtual_memory().total,
-        "gpus": [],
-        "monitors": [],
-        "safe_mode": SAFE_MODE,
+        "cpu": None,
+        "ram_bytes": None,
+        "gpus": None,
+        "monitors": None,
+        "safe_mode": None,
     }
+    try:
+        import psutil
 
+        data["cpu"] = {"count": psutil.cpu_count(logical=True)}
+        data["ram_bytes"] = psutil.virtual_memory().total
+    except Exception:
+        pass
     try:
         import torch
 
         if torch.cuda.is_available():
-            data["gpus"] = [
-                torch.cuda.get_device_name(i) for i in range(torch.cuda.device_count())
-            ]
+            data["gpus"] = [torch.cuda.get_device_name(i) for i in range(torch.cuda.device_count())]
     except Exception:
         pass
-
     try:
-        import mss as mss_lib
+        from screeninfo import get_monitors
 
-        with mss_lib.mss() as sct:  # type: ignore[attr-defined]
-            for mon in sct.monitors[1:]:  # first entry is virtual monitor
-                data["monitors"].append(
-                    {"width": int(mon["width"]), "height": int(mon["height"])}
-                )
+        data["monitors"] = [
+            {"width": m.width, "height": m.height} for m in get_monitors()
+        ]
     except Exception:
         pass
+    try:
+        from settings import SAFE_MODE
 
-    return data
+        data["safe_mode"] = bool(SAFE_MODE)
+    except Exception:
+        data["safe_mode"] = None
+    return {"kind": "ok", "result": data}
+
+
+__all__ = ["capture_screen", "ocr", "info"]


### PR DESCRIPTION
## Summary
- Implement read-only tools with consistent `{kind,message,code}` envelopes and dependency checks
- Register all tools with schemas, allowlists, and optional dependencies split into `requirements-optional.txt`
- Update sandboxes to log registered tools and provide examples for `ui.what_under_mouse` and `web.read`

## Testing
- ✅ `pytest -q`
- ⚠️ `LLM_ENDPOINT=http://localhost:8000 LLM_MODEL=dummy python experiments/llm_sandbox/nu_repl.py <<'EOF'
Hello
EOF` *(missing optional dependency: llama_cpp)*
- ⚠️ `LLM_ENDPOINT=http://localhost:8000 LLM_MODEL=dummy python experiments/llm_sandbox/run_llm_eval_llamacpp.py 2>&1 | head -n 15` *(missing optional dependency: llama_cpp)*

------
https://chatgpt.com/codex/tasks/task_e_68aba77a7cfc83218526604642da36c0