### PR TITLE
make llama cpp fallback optional

### DIFF
--- a/Milestone_llm.md
+++ b/Milestone_llm.md
@@ -91,6 +91,7 @@ Dependências opcionais (`requirements-optional.txt`): `mss`, `Pillow`, `pytesse
 - `missing_dep` – instale dependência ausente (`pip install -r requirements-optional.txt` ou binário externo)
 - `forbidden_path` – caminho fora do allowlist (use diretórios dentro do repositório)
 - `timeout` – reexecute ou verifique conectividade
+- `LLM endpoint indisponível e fallback local desativado/ausente` – defina `LLM_ENDPOINT` ou instale/configure `llama_cpp`; para smoketests sem `llama_cpp`, exporte `LLM_DISABLE_LOCAL_FALLBACK=1` e utilize um endpoint como `dummy_llm.py` (o aviso "missing llama_cpp" não deve mais aparecer)
 
 > Observação: Ferramentas de **ação** (click/type/open/write) **ficam para LLM‑1**. Se desejar já suportar “criar um arquivo” sem tocar no sistema, habilite **opcionalmente** a tool `doc.ppt_generate` que salva **apenas** em `exports/` (SAFE_MODE on).
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,34 @@ python screenshot.py --json --window "janela_que_nao_existe" erro.png
 
 Para detalhes completos de configuração, uso da CLI e API, consulte [docs/usage.md](docs/usage.md).
 
+### Smoketest LLM
+
+1. Inicie o endpoint de teste:
+
+```sh
+python experiments/llm_sandbox/dummy_llm.py
+```
+
+2. Em outro terminal, execute os wrappers com o fallback local desabilitado.
+
+**Bash**
+
+```sh
+export LLM_ENDPOINT=http://127.0.0.1:8000
+export LLM_MODEL=dummy
+export LLM_DISABLE_LOCAL_FALLBACK=1
+python experiments/llm_sandbox/nu_repl.py <<< "Hello"
+```
+
+**PowerShell**
+
+```powershell
+$env:LLM_ENDPOINT="http://127.0.0.1:8000"
+$env:LLM_MODEL="dummy"
+$env:LLM_DISABLE_LOCAL_FALLBACK="1"
+python experiments/llm_sandbox/run_llm_eval_llamacpp.py
+```
+
 <a id="log-config"></a>
 ## Configurações de log
 
@@ -64,6 +92,7 @@ Principais dependências:
 - `psutil` para informações de processos.
 - `fastapi` para o servidor HTTP.
 - `pygetwindow` (opcional) para manipulação de janelas.
+- `llama-cpp-python` (opcional) para fallback local da LLM – CPU: `pip install llama-cpp-python`; AMD ROCm: instale sua build local; NVIDIA/CUDA: wheel específico.
 
 ## Desenvolvimento
 

--- a/experiments/llm_sandbox/dummy_llm.py
+++ b/experiments/llm_sandbox/dummy_llm.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+app = FastAPI()
+
+
+@app.post("/v1/chat/completions")
+async def chat(payload: Dict[str, Any]) -> JSONResponse:  # type: ignore[override]
+    messages = payload.get("messages", [])
+    content = "dummy response"
+    if messages:
+        last = str(messages[-1].get("content", ""))
+        if "tool" in last.lower():
+            content = '<toolcall>{"name":"system.info","args":{}}</toolcall>'
+    data = {"choices": [{"message": {"content": content}}], "usage": {}}
+    return JSONResponse(content=data, media_type="application/json")
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    port = int(os.getenv("PORT", "8000"))
+    uvicorn.run(app, host="127.0.0.1", port=port)

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -4,3 +4,4 @@ pytesseract>=0.3.13
 screeninfo
 pygetwindow
 psutil
+llama-cpp-python>=0.2.90 # CPU: pip install llama-cpp-python; AMD ROCm: instale sua build local; NVIDIA/CUDA: wheel específico

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ pytest-cov>=5.0.0
 httpx
 uvicorn
 requests
-llama-cpp-python>=0.2.90 # fallback local; wheel padrão é CPU-only

--- a/tests/test_llm_fallback_disabled.py
+++ b/tests/test_llm_fallback_disabled.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import requests
+import pytest
+
+from experiments.llm_sandbox.nu_repl import llamacpp_chat
+
+
+def test_fallback_disabled(monkeypatch):
+    monkeypatch.setenv("LLM_ENDPOINT", "http://dummy")
+    monkeypatch.setenv("LLM_DISABLE_LOCAL_FALLBACK", "1")
+
+    def fake_post(*args, **kwargs):  # simulate endpoint down
+        raise requests.ConnectionError
+
+    monkeypatch.setattr("experiments.llm_sandbox.nu_repl.requests.post", fake_post)
+    with pytest.raises(RuntimeError) as exc:
+        llamacpp_chat([{"role": "user", "content": "hi"}])
+    assert "LLM endpoint indisponível e fallback local desativado/ausente" in str(
+        exc.value
+    )

--- a/tools/ui.py
+++ b/tools/ui.py
@@ -26,6 +26,7 @@ def what_under_mouse() -> Dict[str, Any]:
     window = None
     try:
         import pygetwindow as gw
+
         w = None
         if hasattr(gw, "getWindowsAt"):
             ws = gw.getWindowsAt(x, y)
@@ -35,7 +36,16 @@ def what_under_mouse() -> Dict[str, Any]:
             w = gw.getActiveWindow()
         if w is not None:
             title = getattr(w, "title", "") or ""
-            app = getattr(w, "title", "") or ""
+            app: str | None = None
+            try:
+                import psutil
+                import win32process  # type: ignore[import-not-found]
+
+                if hasattr(w, "_hWnd"):
+                    _, pid = win32process.GetWindowThreadProcessId(int(w._hWnd))
+                    app = psutil.Process(pid).name()
+            except Exception:
+                app = None
             window = {"title": title, "app": app}
     except Exception:
         window = None
@@ -50,7 +60,10 @@ def what_under_mouse() -> Dict[str, Any]:
             control = {"role": role, "name": name}
     except Exception:
         control = None
-    return {"kind": "ok", "result": {"x": x, "y": y, "window": window, "control": control}}
+    return {
+        "kind": "ok",
+        "result": {"x": x, "y": y, "window": window, "control": control},
+    }
 
 
 __all__ = ["what_under_mouse"]


### PR DESCRIPTION
## Summary
- make local llama.cpp fallback optional via `LLM_DISABLE_LOCAL_FALLBACK`
- add dummy FastAPI endpoint for smoke tests
- harden tools and docs for updated smoke workflow

## Testing
- `pre-commit run --files requirements.txt requirements-optional.txt experiments/llm_sandbox/dummy_llm.py tools/system.py tools/ui.py experiments/llm_sandbox/nu_repl.py experiments/llm_sandbox/run_llm_eval_llamacpp.py README.md Milestone_llm.md tests/test_agent_local.py tests/test_llm_fallback_disabled.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68abae8c3df0832190c1fd511c5fe363