### PR TITLE
Handle toolcalls without closing tag

### DIFF
--- a/chatgpt.md
+++ b/chatgpt.md
@@ -2,6 +2,6 @@
 Sempre mantenha este tutorial. Antes de iniciar uma nova tarefa, apague todo o conteúdo abaixo deste bloco e escreva apenas o que foi feito, como foi feito e por que foi feito.
 
 ## Registro de alterações
-- **Objetivo**: atualizar o roadmap marcando as etapas concluídas do Milestone M0.
-- **Como**: revisar código e assinalar com `X` as etapas 3–5 em `Milestone.md`.
-- **Por que**: refletir o estado atual do projeto e facilitar o acompanhamento do progresso.
+- **Objetivo**: tornar o parser de toolcalls tolerante à ausência de `</toolcall>` e manter validações de nome/argumentos.
+- **Como**: ajustar `_parse_toolcalls` em `agent_local.py` para auto-fechar a tag usando o menor sufixo JSON balanceado, validar `name` e `args` (regex e cap de 2 KB) e adicionar testes cobrindo casos simples, aninhados, lixo após `}`, múltiplas aberturas, limite de args e nomes inválidos.
+- **Por que**: reduzir atrito com modelos que omitem a tag final, sem afetar fluxos existentes.


### PR DESCRIPTION
## Summary
- Auto-close `<toolcall>` blocks missing a closing tag by scanning for balanced JSON and ignoring ambiguous openings
- Validate `name` and `args` when parsing toolcalls, including 2 KB argument cap and `ast.literal_eval` fallback
- Test invalid names and oversized arguments and update changelog

## Testing
- `pre-commit run --files agent_local.py tests/test_agent_local.py chatgpt.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abb3e37a6c8321bcaa673b68875f39