### PR TITLE
Add OCR adapter and image crop tool with resilient retries

### DIFF
--- a/agent_local.py
+++ b/agent_local.py
@@ -725,7 +725,7 @@ class Agent:
                     if envelope.get("kind") != "error":
                         break
                     if i + 1 < attempts:
-                        time.sleep(0.2 * (i + 1))
+                        time.sleep(0.2 * (2 ** i))
 
                 messages.append(
                     {

--- a/tests/test_dispatcher_tools.py
+++ b/tests/test_dispatcher_tools.py
@@ -32,6 +32,15 @@ def test_fs_and_archive(tmp_path):
     )
     assert env["kind"] == "ok" and "hello.txt" in env["result"]
 
+    env = dispatch(
+        {
+            "name": "fs.list",
+            "args": {"path": str(tmp_path), "recursive": True, "allow": [str(tmp_path)]},
+        },
+        request_id="2b",
+    )
+    assert env["kind"] == "ok" and "hello.txt" in env["result"]
+
     zpath = tmp_path / "a.zip"
     with zipfile.ZipFile(zpath, "w") as z:
         z.writestr("readme.txt", "zip hi")

--- a/tests/test_mouse_crop_ocr.py
+++ b/tests/test_mouse_crop_ocr.py
@@ -1,0 +1,52 @@
+import base64
+import sys
+import types
+
+# stub sanitize deps
+sys.modules["agent_local"] = types.SimpleNamespace(
+    _redact=lambda x: x, _truncate=lambda x: x
+)
+
+from tools import ui, system, image  # noqa: E402
+import ocr as ocr_module  # noqa: E402
+
+
+def test_mouse_crop_ocr_pipeline(monkeypatch):
+    # stub minimal PIL modules within test
+    class Img:
+        def crop(self, box):
+            return self
+
+        def save(self, buf, format="PNG"):
+            buf.write(b"fake")
+
+    fake_image_module = types.SimpleNamespace(open=lambda b: Img())
+    monkeypatch.setitem(sys.modules, "PIL", types.SimpleNamespace(Image=fake_image_module))
+    monkeypatch.setitem(sys.modules, "PIL.Image", fake_image_module)
+
+    monkeypatch.setattr(
+        ui,
+        "what_under_mouse",
+        lambda: {"kind": "ok", "result": {"x": 5, "y": 5, "window": None, "control": None}},
+    )
+
+    screenshot_b64 = base64.b64encode(b"fake").decode("ascii")
+    monkeypatch.setattr(
+        system,
+        "capture_screen",
+        lambda bounds=None: {"kind": "ok", "result": {"png_base64": screenshot_b64}},
+    )
+
+    monkeypatch.setattr(
+        ocr_module, "extract_text", lambda img, region=None: ("hi", 1.0)
+    )
+
+    mouse = ui.what_under_mouse()
+    shot = system.capture_screen()
+    cropped = image.crop(
+        png_base64=shot["result"]["png_base64"], x=0, y=0, w=1, h=1
+    )
+    assert cropped["kind"] == "ok"
+    out = system.ocr(png_base64=cropped["result"]["png_base64"])
+    assert out["kind"] == "ok"
+    assert out["result"]["text"] == "hi"

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from registry import register_tool, REGISTRY
-from . import system, fs, archive, web, ui
+from . import system, fs, archive, web, ui, image
 
 __all__ = ["register_all_tools"]
 
@@ -22,14 +22,40 @@ def register_all_tools() -> None:
     register_tool(
         name="system.ocr",
         version="1",
-        summary="ocr screen region",
+        summary="ocr image or screen region",
         safety="read",
         timeout_ms=5000,
         rate_limit_per_min=30,
         enabled_in_safe_mode=True,
         func=system.ocr,
-        schema={"args": {"type": "object", "properties": {"bounds": {"type": "object"},}},
-                 "returns": {"type": "object", "properties": {"text": {"type": "string"}}}},
+        schema={
+            "args": {
+                "type": "object",
+                "properties": {
+                    "bounds": {"type": "object"},
+                    "path": {"type": "string"},
+                    "png_base64": {"type": "string"},
+                },
+            },
+            "returns": {
+                "type": "object",
+                "properties": {
+                    "text": {"type": "string"},
+                    "confidence": {"type": "number"},
+                },
+            },
+        },
+    )
+    register_tool(
+        name="system.toolspec",
+        version="1",
+        summary="list available tools and schemas",
+        safety="read",
+        timeout_ms=1000,
+        rate_limit_per_min=10,
+        enabled_in_safe_mode=True,
+        func=system.toolspec,
+        schema={"args": {"type": "object", "properties": {}}, "returns": {"type": "object"}},
     )
     register_tool(
         name="system.info",
@@ -40,7 +66,11 @@ def register_all_tools() -> None:
         rate_limit_per_min=60,
         enabled_in_safe_mode=True,
         func=system.info,
-        schema={"args": {"type": "object", "properties": {}}, "returns": {"type": "object"}},
+        schema={
+            "args": {"type": "object", "properties": {}},
+            "returns": {"type": "object"},
+            "x-retry": 2,
+        },
     )
     register_tool(
         name="fs.list",
@@ -51,8 +81,16 @@ def register_all_tools() -> None:
         rate_limit_per_min=60,
         enabled_in_safe_mode=True,
         func=fs.list,
-        schema={"args": {"type": "object", "properties": {"path": {"type": "string"}}},
-                 "returns": {"type": "array", "items": {"type": "string"}}},
+        schema={
+            "args": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "recursive": {"type": "boolean"},
+                },
+            },
+            "returns": {"type": "array", "items": {"type": "string"}},
+        },
     )
     register_tool(
         name="fs.read",
@@ -128,6 +166,29 @@ def register_all_tools() -> None:
                     },
                 },
             },
+        },
+    )
+    register_tool(
+        name="image.crop",
+        version="1",
+        summary="crop image region",
+        safety="read",
+        timeout_ms=1000,
+        rate_limit_per_min=30,
+        enabled_in_safe_mode=True,
+        func=image.crop,
+        schema={
+            "args": {
+                "type": "object",
+                "properties": {
+                    "png_base64": {"type": "string"},
+                    "x": {"type": "integer"},
+                    "y": {"type": "integer"},
+                    "w": {"type": "integer"},
+                    "h": {"type": "integer"},
+                },
+            },
+            "returns": {"type": "object", "properties": {"png_base64": {"type": "string"}}},
         },
     )
     try:

--- a/tools/fs.py
+++ b/tools/fs.py
@@ -12,7 +12,7 @@ def _sanitize(text: str) -> str:
     return _truncate(_redact(text))
 
 
-def list(path: str, allow: List[str] | None = None) -> Dict:
+def list(path: str, recursive: bool | None = None, allow: List[str] | None = None) -> Dict:
     p = Path(path)
     allowed = ALLOWED + [Path(a) for a in (allow or [])]
     rp = p.resolve()
@@ -24,7 +24,16 @@ def list(path: str, allow: List[str] | None = None) -> Dict:
             "hint": "",
         }
     try:
-        names = [c.name for c in p.iterdir()]
+        if recursive:
+            names = []
+            for sub in p.rglob("*"):
+                if sub.is_file() or sub.is_dir():
+                    try:
+                        names.append(str(sub.relative_to(p)))
+                    except Exception:
+                        names.append(str(sub))
+        else:
+            names = [c.name for c in p.iterdir()]
         return {"kind": "ok", "result": names}
     except Exception as e:
         return {

--- a/tools/image.py
+++ b/tools/image.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import base64
+import io
+from typing import Dict, Any
+
+
+def _sanitize(text: str) -> str:
+    from agent_local import _redact, _truncate  # type: ignore
+
+    return _truncate(_redact(text))
+
+
+def crop(png_base64: str, x: int, y: int, w: int, h: int) -> Dict[str, Any]:
+    try:
+        from PIL import Image
+    except Exception:
+        return {
+            "kind": "error",
+            "code": "missing_dep",
+            "message": "pillow not installed",
+            "hint": "pip install -r requirements-optional.txt",
+        }
+    try:
+        data = base64.b64decode(png_base64)
+        img = Image.open(io.BytesIO(data))
+        cropped = img.crop((x, y, x + w, y + h))
+        buf = io.BytesIO()
+        cropped.save(buf, format="PNG")
+        out = base64.b64encode(buf.getvalue()).decode("ascii")
+        png = _sanitize(out)
+        truncated = False
+        if len(png) > 1500:
+            png = png[:1500]
+            truncated = True
+        result: Dict[str, Any] = {"png_base64": png}
+        if truncated:
+            result["truncated"] = True
+        return {"kind": "ok", "result": result}
+    except Exception as e:
+        return {
+            "kind": "error",
+            "code": "crop_failed",
+            "message": str(e),
+            "hint": "",
+        }
+
+
+__all__ = ["crop"]


### PR DESCRIPTION
## Summary
- expand `system.ocr` to handle file paths or base64 images and expose `system.toolspec`
- add `image.crop` utility and allow `fs.list` to accept `recursive`
- tweak retry logic and enrich tool registry; add pipeline and regression tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68abc4a3d98c83218f7ae42d9b403e6f